### PR TITLE
Adding serverless config for retriving ssm parameters from aws

### DIFF
--- a/services/bankid-api/serverless.yml
+++ b/services/bankid-api/serverless.yml
@@ -22,6 +22,7 @@ provider:
   environment:
     stage: ${self:custom.stage}
     resourcesStage: ${self:custom.resourcesStage}
+    bankidEnvs: ${ssm:/bankidTest/${self:custom.resourcesStage}~true}
 
 functions:
   # Defines an HTTP API endpoint that calls the main function in create.js


### PR DESCRIPTION
These changes apply to the bankid service only