### PR TITLE
Helper function for throwing an error if validation checks fails

### DIFF
--- a/libs/validateEventBody.js
+++ b/libs/validateEventBody.js
@@ -1,0 +1,13 @@
+import { throwError } from '@helsingborg-stad/npm-api-error-handling';
+
+/**
+ * @param {obj} body
+ * @param {func} callback the callback function must return an array with the following values [isValid::Boolean, errorStatusCode::Integear, errorMesseage::String], where isValid and errorStatusCode are required and erroMessage is optional.
+ */
+export async function validateEventBody(body, callback) {
+  const [isValid, errorStatusCode, errorMessage] = callback(body);
+  if (!isValid) {
+    throwError(errorStatusCode, errorMessage);
+  }
+  return body;
+}


### PR DESCRIPTION
The purpose with this helper function is to ease the validation of an incoming json request. This is done by handling throwing of errors based on a callback validation function.

An simple implementation of such a callback function could be:

```
validateEventBody(body, exampleValidationCallback)

function exampleValidationCallback(body) {

  // simple validation check
  if (!('someKey' in body)) {
    return [false, 400, 'Some message'];
  }

  return [true];
}
```

Since the validateEventBody function resolves a promise wich throws an error or returns an response. We could use the await-to-js lib to handle the promise.
```
const [error, response] = await to(validateEventBody(body))
` ``