### PR TITLE
Exporting the authorizer function to be used elsewhere

### DIFF
--- a/services/auth/token/serverless.yml
+++ b/services/auth/token/serverless.yml
@@ -68,3 +68,11 @@ functions:
   #         path: hello
   #         method: get
   #         authorizer: authorize
+
+resources:
+  Outputs:
+    AuthorizeLambdaFunctionArn:
+      Export:
+        Name: AuthorizeLambdaFunctionARN
+      Value:
+        Fn::GetAtt: [AuthorizeLambdaFunction, Arn]


### PR DESCRIPTION
Exporting the custom authorizer function, so it can be used imported elsewhere when a route or lambda are in need for token authorization.