### PR TITLE
Fixed promise problems when validating the token

### DIFF
--- a/services/auth/token/helpers/token.js
+++ b/services/auth/token/helpers/token.js
@@ -9,7 +9,7 @@ export function signToken(jsonToSign) {
   return token;
 }
 
-export function verifyToken(token) {
+export async function verifyToken(token) {
   return jwt.verify(token, SECRET_KEY, (error, decoded) => {
     if (error) {
       throwError(401, error.message);

--- a/services/auth/token/lambdas/authorize.js
+++ b/services/auth/token/lambdas/authorize.js
@@ -1,12 +1,10 @@
 import to from 'await-to-js';
-
 import { verifyToken } from '../helpers/token';
 import generateIAMPolicy from '../helpers/generateIAMPolicy';
 
 export async function main(event) {
   const { authorizationToken, methodArn } = event;
   let isAllowed = true;
-
   const [error] = await to(verifyToken(authorizationToken));
   if (error) {
     isAllowed = false;


### PR DESCRIPTION
The returned promise from the verifyToken function was not handled in a correct way that caused the authorizer function to return a 500 internal error response.

This issue is now fixed and the authorizer returns a 403 forbidden error a response with data :D