### PR TITLE
Adopted authorizer to connect on any resource

### DIFF
--- a/services/auth/token/helpers/token.js
+++ b/services/auth/token/helpers/token.js
@@ -10,7 +10,7 @@ export function signToken(jsonToSign) {
 }
 
 export async function verifyToken(token) {
-  return jwt.verify(token, SECRET_KEY, (error, decoded) => {
+  return await jwt.verify(token, SECRET_KEY, (error, decoded) => {
     if (error) {
       throwError(401, error.message);
     }

--- a/services/auth/token/lambdas/authorize.js
+++ b/services/auth/token/lambdas/authorize.js
@@ -3,15 +3,15 @@ import { verifyToken } from '../helpers/token';
 import generateIAMPolicy from '../helpers/generateIAMPolicy';
 
 export async function main(event) {
-  const { authorizationToken, methodArn } = event;
+  const { authorizationToken } = event;
   let isAllowed = true;
-  const [error] = await to(verifyToken(authorizationToken));
+  const [error, decodedToken] = await to(verifyToken(authorizationToken));
   if (error) {
     isAllowed = false;
   }
 
   const effect = isAllowed ? 'Allow' : 'Deny';
-  const IAMPolicy = generateIAMPolicy('user', effect, methodArn);
+  const IAMPolicy = generateIAMPolicy(decodedToken.personalNumber, effect, '*');
 
   return IAMPolicy;
 }

--- a/services/user-api/serverless.yml
+++ b/services/user-api/serverless.yml
@@ -51,3 +51,4 @@ functions:
           path: /users/{personalNumber}
           method: get
           cors: true
+          authorizer: ${cf:hbg-authorizer-${self:custom.stage}.AuthorizeLambdaFunctionQualifiedArn}


### PR DESCRIPTION
The custom authorizer can now connect to any lambda resource that uses an http event. 
As a first use case the user lambda resource now has the authorizer connected to it on a single user GET request.