### PR TITLE
Fix/import authorizer

### DIFF
--- a/services/auth/token/serverless.yml
+++ b/services/auth/token/serverless.yml
@@ -41,7 +41,7 @@ provider:
       Resource: "*"
 
 functions:
-  authorize:
+  authorizer:
     handler: lambdas/authorize.main
 
   generateToken:
@@ -52,19 +52,36 @@ functions:
           method: post
           cors: true
           private: true
-  # Lambda for testing the auhtorization
-  # hello:
-  #   handler: lambdas/hello.main
-  #   events:
-  #     - http:
-  #         path: hello
-  #         method: get
-  #         authorizer: authorize
 
 resources:
+  Resources:
+    AuthorizerPermission:
+      Type: AWS::Lambda::Permission
+      Properties:
+        FunctionName:
+          Fn::GetAtt: AuthorizerLambdaFunction.Arn
+        Action: lambda:InvokeFunction
+        Principal:
+          Fn::Join: ["", ["apigateway.", { Ref: "AWS::URLSuffix" }]]
+    Authorizer:
+      Type: AWS::ApiGateway::Authorizer
+      Properties:
+        Name: ${self:custom.stage}-Authorizer
+        RestApiId: ${self:provider.apiGateway.restApiId}
+        Type: TOKEN
+        IdentitySource: method.request.header.Authorization
+        AuthorizerResultTtlInSeconds: 300
+        AuthorizerUri:
+          Fn::Join:
+            - ""
+            - - "arn:aws:apigateway:"
+              - Ref: "AWS::Region"
+              - ":lambda:path/2015-03-31/functions/"
+              - Fn::GetAtt: "AuthorizerLambdaFunction.Arn"
+              - "/invocations"
   Outputs:
-    AuthorizeLambdaFunctionArn:
-      Export:
-        Name: AuthorizeLambdaFunctionARN
+    AuthorizerId:
       Value:
-        Fn::GetAtt: [AuthorizeLambdaFunction, Arn]
+        Ref: Authorizer
+      Export:
+        Name: ${self:custom.stage}-authorizerId

--- a/services/user-api/serverless.yml
+++ b/services/user-api/serverless.yml
@@ -51,4 +51,6 @@ functions:
           path: /users/{personalNumber}
           method: get
           cors: true
-          # authorizer: ${cf:hbg-authorizer-${self:custom.stage}.AuthorizeLambdaFunctionQualifiedArn}
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId


### PR DESCRIPTION
This PR fixes the issue of not being able to import the Custom Authorizer Lambda on more than one service. The problem in itself was due to that in order to reference the deployed authorizer it must be imported through the id of the lambda. If the import of an authorizer is made from the authorizers arn the import will try to deploy the custom authorizer and attach it to the ApiGateway that already has a an authorizer connected to it.

The Solution to this problem was to export the Authorizer id and tell the ApiGateway that we want to use this specific Lambda to handle Authorization. Then when we want to import the Authorizer in a service we can do a direct reference in its ID, which will prevent the service to setup it's own Authorizer in the stack once we deploy it.