### PR TITLE
Fix/cases get pno from token

### DIFF
--- a/services/cases-api/lambdas/list.js
+++ b/services/cases-api/lambdas/list.js
@@ -1,4 +1,5 @@
 import to from 'await-to-js';
+import jwt from 'jsonwebtoken';
 import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 
 import config from '../../../config';
@@ -9,8 +10,15 @@ import * as dynamoDb from '../../../libs/dynamoDb';
  * Handler function for retrieving user cases from dynamodb
  */
 export async function main(event) {
-  const userId = event.headers.Authorization;
-  const casePartitionKey = `USER#${userId}`;
+  const authorizationValue = event.headers.Authorization;
+
+  const token = authorizationValue.includes('Bearer')
+    ? authorizationValue.substr(authorizationValue.indexOf(' ') + 1)
+    : authorizationValue;
+
+  const decodedToken = jwt.decode(token);
+
+  const casePartitionKey = `USER#${decodedToken.personalNumber}`;
   const caseSortKey = casePartitionKey;
 
   const params = {

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -62,6 +62,9 @@ functions:
           path: /cases
           method: get
           cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId
 
   create:
     handler: lambdas/create.main


### PR DESCRIPTION
Before the Authorization header was used completely incorrect. The Authorization header was used to pass down a userId that later on was used to get cases from dynamodb. 

Now the Authorization header is used to pass down a valid accessToken from then client. Then we decode the token to get the payload from the token which determine the cases that we should get from AWS DynamoDB. With other words you can't get a user without a valid accessToken with this update.