### PR TITLE
fix: get user from token payload

### DIFF
--- a/services/user-api/lambdas/get.js
+++ b/services/user-api/lambdas/get.js
@@ -1,4 +1,5 @@
 import to from 'await-to-js';
+import jwt from 'jsonwebtoken';
 import camelCase from 'camelcase';
 import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 
@@ -10,12 +11,18 @@ import * as dynamoDb from '../../../libs/dynamoDb';
  * Get the user with the personal number specified in the path
  */
 export const main = async event => {
-  const { personalNumber } = event.pathParameters;
+  const authorizationValue = event.headers.Authorization;
+
+  const token = authorizationValue.includes('Bearer')
+    ? authorizationValue.substr(authorizationValue.indexOf(' ') + 1)
+    : authorizationValue;
+
+  const decodedToken = jwt.decode(token);
 
   const params = {
     TableName: config.users.tableName,
     Key: {
-      personalNumber,
+      personalNumber: decodedToken.personalNumber,
     },
   };
 


### PR DESCRIPTION
Before when a get request was made towards users/{personalNumber} we just returned the user that was requested if the accessToken was valid. This is however a problem, since it means that anyone with a valid token can request any user, if they passed the correct personalNumber in the path.

To fix this issue we are now relaying on the payload of the jwt token to pass the personalNumber instead of retrieving it from the path. This means that the path is currently completely useless, but since the application Mitt Helsingborg uses it we keep the personalNumber in the path. This will however be replaced in a near future with a new endpoint.