### PR TITLE
fix(cases): flatten response objects from cases-api

### DIFF
--- a/services/cases-api/lambdas/create.js
+++ b/services/cases-api/lambdas/create.js
@@ -48,14 +48,14 @@ export async function main(event) {
   if (dynamodbError) return response.failure(dynamodbError);
 
   return response.success(201, {
-    type: 'cases',
     id: caseId,
-    attributes: {
-      personalNumber: validatedEventBody.personalNumber,
-      type: validatedEventBody.type,
-      status: validatedEventBody.status,
-      data: validatedEventBody.data,
-    },
+    formId: validatedEventBody.formId,
+    personalNumber: validatedEventBody.personalNumber,
+    type: validatedEventBody.type,
+    status: validatedEventBody.status,
+    data: validatedEventBody.data,
+    createdAt: createdAt,
+    updatedAt: createdAt,
   });
 }
 

--- a/services/cases-api/lambdas/get.js
+++ b/services/cases-api/lambdas/get.js
@@ -28,19 +28,9 @@ export async function main(event) {
 
   if (queryResponse.Count > 0) {
     const [item] = queryResponse.Items;
-    const { id, ...attributes } = omitObjectKeys(item, [
-      'ITEM_TYPE',
-      // 'updatedAt',
-      // 'createdAt',
-      'PK',
-      'SK',
-    ]);
+    const filteredItem = omitObjectKeys(item, ['ITEM_TYPE', 'PK', 'SK']);
 
-    return response.success(200, {
-      type: 'cases',
-      id,
-      attributes,
-    });
+    return response.success(200, filteredItem);
   } else {
     return response.success(200, {
       type: 'cases',

--- a/services/cases-api/lambdas/list.js
+++ b/services/cases-api/lambdas/list.js
@@ -27,19 +27,9 @@ export async function main(event) {
 
   if (queryResponse.Count > 0) {
     const cases = queryResponse.Items.map(item => {
-      const { id, ...attributes } = omitObjectKeys(item, [
-        'ITEM_TYPE',
-        // 'updatedAt',
-        // 'createdAt',
-        'PK',
-        'SK',
-      ]);
+      const filteredItem = omitObjectKeys(item, ['ITEM_TYPE', 'PK', 'SK']);
 
-      return {
-        type: 'cases',
-        id,
-        attributes,
-      };
+      return filteredItem;
     });
 
     return response.success(200, cases);

--- a/services/cases-api/lambdas/update.js
+++ b/services/cases-api/lambdas/update.js
@@ -68,7 +68,8 @@ export async function main(event) {
   if (error) return response.failure(error);
 
   return response.success(200, {
-    caseId,
+    id: caseId,
+    formId: queryResponse.Attributes.formId,
     personalNumber: userId,
     type: queryResponse.Attributes.type,
     currentStep: queryResponse.Attributes.currentStep,


### PR DESCRIPTION
In the cases api, we were returning objects with the structure {type, id, attributes:{ data:{}, ...}}. Then in the app, we flatten these objects out, removing the attributes. So this is pretty stupid and as far I can see, separating some things into attributes serves no purpose, so this changes it to be flat from the beginning.