### PR TITLE
Fix: case return values

### DIFF
--- a/services/cases-api/lambdas/create.js
+++ b/services/cases-api/lambdas/create.js
@@ -51,6 +51,7 @@ export async function main(event) {
     type: 'cases',
     id: caseId,
     attributes: {
+      formId: validatedEventBody.formId,
       personalNumber: validatedEventBody.personalNumber,
       type: validatedEventBody.type,
       status: validatedEventBody.status,

--- a/services/cases-api/lambdas/update.js
+++ b/services/cases-api/lambdas/update.js
@@ -68,13 +68,15 @@ export async function main(event) {
   if (error) return response.failure(error);
 
   return response.success(200, {
-    caseId,
-    personalNumber: userId,
-    type: queryResponse.Attributes.type,
-    currentStep: queryResponse.Attributes.currentStep,
-    status: queryResponse.Attributes.status,
-    updatedAt: queryResponse.Attributes.updatedAt,
-    data: queryResponse.Attributes.data,
+    type: 'cases',
+    id: caseId,
+    attributes: {
+      personalNumber: userId,
+      type: queryResponse.Attributes.type,
+      currentStep: queryResponse.Attributes.currentStep,
+      status: queryResponse.Attributes.status,
+      data: queryResponse.Attributes.data,
+    },
   });
 }
 


### PR DESCRIPTION
Adds some needed values (eg formId) to the response of create, and updated the response from update to follow the JSON standard, because it didn't before. 