### PR TITLE
fix: authorizer ruturns a 401 when unauthorized

### DIFF
--- a/services/auth/token/lambdas/authorize.js
+++ b/services/auth/token/lambdas/authorize.js
@@ -4,14 +4,13 @@ import generateIAMPolicy from '../helpers/generateIAMPolicy';
 
 export async function main(event) {
   const { authorizationToken } = event;
-  let isAllowed = true;
   const [error, decodedToken] = await to(verifyToken(authorizationToken));
   if (error) {
-    isAllowed = false;
+    // By thorwing this error AWS returns a 401 response with the message unauthorized
+    throw Error('Unauthorized');
   }
 
-  const effect = isAllowed ? 'Allow' : 'Deny';
-  const IAMPolicy = generateIAMPolicy(decodedToken.personalNumber, effect, '*');
+  const IAMPolicy = generateIAMPolicy(decodedToken.personalNumber, 'Allow', '*');
 
   return IAMPolicy;
 }


### PR DESCRIPTION
Earlier when a token was invalid the error response on a request was 500 internal server error.
This issue is now solved so that if the token is invalid a 401 unauthorized response is returned.