### PR TITLE
Get pnr from token in cases-api

### DIFF
--- a/libs/token.js
+++ b/libs/token.js
@@ -1,0 +1,16 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * Takes an http event with an jwt authorization header, and returns the decoded info from it. Does not check if the token is valid, that should be handled by an authorizer.
+ * @param {*} httpEvent the event passed to the lambda
+ */
+export function decodeToken(httpEvent) {
+  const authorizationValue = httpEvent.headers.Authorization;
+
+  const token = authorizationValue.includes('Bearer')
+    ? authorizationValue.substr(authorizationValue.indexOf(' ') + 1)
+    : authorizationValue;
+
+  const decodedToken = jwt.decode(token);
+  return decodeToken;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10894,6 +10894,16 @@
       "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
+    "serverless-add-api-key": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/serverless-add-api-key/-/serverless-add-api-key-4.1.1.tgz",
+      "integrity": "sha512-uMH+AztRTOuxuA9fApfiYe8L5hbcuGWiQT9Usx7F+8nfsHj7vmS2dbWNkUwsOQwVzByuwbmqGjZwBqmQazKBnw==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.421.0",
+        "chalk": "^2.4.1"
+      }
+    },
     "serverless-bundle": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/serverless-bundle/-/serverless-bundle-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
     "prettier": "^1.19.1",
+    "serverless-add-api-key": "^4.1.1",
     "serverless-bundle": "^1.3.2",
     "serverless-offline": "^5.12.1"
   },

--- a/serverless.common.yml
+++ b/serverless.common.yml
@@ -6,3 +6,8 @@ custom:
     prod: prod
     dev: dev
   resourcesStage: ${self:custom.resourcesStages.${self:custom.stage}, self:custom.resourcesStages.dev}
+  
+  apiKeys:
+    - name: helsingborg-io-apikey
+      usagePlan:
+        name: "hbg-authorizer-dev"

--- a/services/cases-api/lambdas/list.js
+++ b/services/cases-api/lambdas/list.js
@@ -5,19 +5,13 @@ import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 import config from '../../../config';
 import * as response from '../../../libs/response';
 import * as dynamoDb from '../../../libs/dynamoDb';
+import { decodeToken } from '../../../libs/token';
 
 /**
  * Handler function for retrieving user cases from dynamodb
  */
 export async function main(event) {
-  const authorizationValue = event.headers.Authorization;
-
-  const token = authorizationValue.includes('Bearer')
-    ? authorizationValue.substr(authorizationValue.indexOf(' ') + 1)
-    : authorizationValue;
-
-  const decodedToken = jwt.decode(token);
-
+  const decodedToken = decodeToken(event);
   const casePartitionKey = `USER#${decodedToken.personalNumber}`;
   const caseSortKey = casePartitionKey;
 

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -54,6 +54,9 @@ functions:
           path: /cases/{caseId}
           method: get
           cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId
 
   list:
     handler: lambdas/list.main
@@ -73,6 +76,9 @@ functions:
           path: /cases
           method: post
           cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId
 
   update:
     handler: lambdas/update.main
@@ -81,6 +87,9 @@ functions:
           path: /cases/{caseId}
           method: put
           cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId
 
   delete:
     handler: lambdas/delete.main
@@ -89,3 +98,6 @@ functions:
           path: /cases/{caseId}
           method: delete
           cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId

--- a/services/forms-api3/serverless.yaml
+++ b/services/forms-api3/serverless.yaml
@@ -3,6 +3,7 @@ service: hbg-forms3
 plugins:
   - serverless-bundle
   - serverless-offline
+  - serverless-add-api-key
 
 custom: ${file(../../serverless.common.yml):custom}
 
@@ -15,8 +16,6 @@ provider:
   stage: dev
   region: eu-north-1
   endpointType: regional
-  apiKeys:
-    - helsingborg-io-forms-apikey
   logs:
     restApi: true
   tracing:

--- a/services/forms-api3/serverless.yaml
+++ b/services/forms-api3/serverless.yaml
@@ -15,6 +15,8 @@ provider:
   stage: dev
   region: eu-north-1
   endpointType: regional
+  apiKeys:
+    - helsingborg-io-forms-apikey
   logs:
     restApi: true
   tracing:
@@ -54,6 +56,7 @@ functions:
           path: /forms3
           method: get
           cors: true
+          private: true
 
   getForm:
     handler: lambdas/getForm.main
@@ -62,6 +65,8 @@ functions:
           path: /forms3/{formId}
           method: get
           cors: true
+          private: true
+
 
   createForm:
     handler: lambdas/createForm.main
@@ -70,6 +75,8 @@ functions:
           path: /forms3
           method: post
           cors: true
+          private: true
+
 
   updateForm:
     handler: lambdas/updateForm.main
@@ -78,6 +85,8 @@ functions:
           path: /forms3/{formId}
           method: put
           cors: true
+          private: true
+
 
   deleteForm:
     handler: lambdas/deleteForm.main
@@ -86,3 +95,5 @@ functions:
           path: /forms3/{formId}
           method: delete
           cors: true
+          private: true
+

--- a/services/user-api/lambdas/get.js
+++ b/services/user-api/lambdas/get.js
@@ -6,18 +6,13 @@ import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 import config from '../../../config';
 import * as response from '../../../libs/response';
 import * as dynamoDb from '../../../libs/dynamoDb';
+import { decodeToken } from '../../../libs/token';
 
 /**
  * Get the user with the personal number specified in the path
  */
 export const main = async event => {
-  const authorizationValue = event.headers.Authorization;
-
-  const token = authorizationValue.includes('Bearer')
-    ? authorizationValue.substr(authorizationValue.indexOf(' ') + 1)
-    : authorizationValue;
-
-  const decodedToken = jwt.decode(token);
+  const decodedToken = decodeToken(event);
 
   const params = {
     TableName: config.users.tableName,


### PR DESCRIPTION
Updates the cases-api to get the Personal number from the decoded token rather than reading it from plaintext in the header or body. 
Note that when deploying this to the dev-AWS, the app will need to be changed in order to work, but the changes should be only to the case context. 

Also refactored out the decoding of the token into a separate function placed in libs, since it's used across multiple services.