### PR TITLE
feat(forms3): add api key to forms3 and makes it private

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10894,6 +10894,16 @@
       "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
+    "serverless-add-api-key": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/serverless-add-api-key/-/serverless-add-api-key-4.1.1.tgz",
+      "integrity": "sha512-uMH+AztRTOuxuA9fApfiYe8L5hbcuGWiQT9Usx7F+8nfsHj7vmS2dbWNkUwsOQwVzByuwbmqGjZwBqmQazKBnw==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.421.0",
+        "chalk": "^2.4.1"
+      }
+    },
     "serverless-bundle": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/serverless-bundle/-/serverless-bundle-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
     "prettier": "^1.19.1",
+    "serverless-add-api-key": "^4.1.1",
     "serverless-bundle": "^1.3.2",
     "serverless-offline": "^5.12.1"
   },

--- a/serverless.common.yml
+++ b/serverless.common.yml
@@ -6,3 +6,8 @@ custom:
     prod: prod
     dev: dev
   resourcesStage: ${self:custom.resourcesStages.${self:custom.stage}, self:custom.resourcesStages.dev}
+  
+  apiKeys:
+    - name: helsingborg-io-apikey
+      usagePlan:
+        name: "hbg-authorizer-dev"

--- a/services/forms-api3/serverless.yaml
+++ b/services/forms-api3/serverless.yaml
@@ -3,6 +3,7 @@ service: hbg-forms3
 plugins:
   - serverless-bundle
   - serverless-offline
+  - serverless-add-api-key
 
 custom: ${file(../../serverless.common.yml):custom}
 
@@ -15,8 +16,6 @@ provider:
   stage: dev
   region: eu-north-1
   endpointType: regional
-  apiKeys:
-    - helsingborg-io-forms-apikey
   logs:
     restApi: true
   tracing:

--- a/services/forms-api3/serverless.yaml
+++ b/services/forms-api3/serverless.yaml
@@ -15,6 +15,8 @@ provider:
   stage: dev
   region: eu-north-1
   endpointType: regional
+  apiKeys:
+    - helsingborg-io-forms-apikey
   logs:
     restApi: true
   tracing:
@@ -54,6 +56,7 @@ functions:
           path: /forms3
           method: get
           cors: true
+          private: true
 
   getForm:
     handler: lambdas/getForm.main
@@ -62,6 +65,8 @@ functions:
           path: /forms3/{formId}
           method: get
           cors: true
+          private: true
+
 
   createForm:
     handler: lambdas/createForm.main
@@ -70,6 +75,8 @@ functions:
           path: /forms3
           method: post
           cors: true
+          private: true
+
 
   updateForm:
     handler: lambdas/updateForm.main
@@ -78,6 +85,8 @@ functions:
           path: /forms3/{formId}
           method: put
           cors: true
+          private: true
+
 
   deleteForm:
     handler: lambdas/deleteForm.main
@@ -86,3 +95,5 @@ functions:
           path: /forms3/{formId}
           method: delete
           cors: true
+          private: true
+


### PR DESCRIPTION
Hides all the endpoints of the forms3 api behind a new apikey, specific to this api. This is done in part because obviously this api should not be fully public, and in part to have an easy method of securing the form builder. 

Note that on deploying this, we need to change the app so that it sends this key when getting forms. 
Later we might want to use the same api key, but this is a little harder to setup, so for now lets use this.