### PR TITLE
fix: checking if authorization header contains bearer prefix or not

### DIFF
--- a/services/auth/token/lambdas/authorize.js
+++ b/services/auth/token/lambdas/authorize.js
@@ -4,7 +4,12 @@ import generateIAMPolicy from '../helpers/generateIAMPolicy';
 
 export async function main(event) {
   const { authorizationToken } = event;
-  const [error, decodedToken] = await to(verifyToken(authorizationToken));
+
+  const token = authorizationToken.includes('Bearer')
+    ? authorizationToken.substr(authorizationToken.indexOf(' ') + 1)
+    : authorizationToken;
+
+  const [error, decodedToken] = await to(verifyToken(token));
   if (error) {
     // By thorwing this error AWS returns a 401 response with the message unauthorized
     throw Error('Unauthorized');


### PR DESCRIPTION
When we send tokens in the Authorization header we would like to prefix them with the token type, in our case Bearer. This was not taken into consideration when implementation the custom authorizer lambda and therefore an Authorization header with Bearer as prefix would be treated as an invalid token.

This issue is now fixed and the custom authorizer does allow the Authorization header to be prefixed with Bearer. The prefix can also be excluded.