### PR TITLE
Feat/s3 signed upload url

### DIFF
--- a/libs/S3.js
+++ b/libs/S3.js
@@ -16,46 +16,6 @@ async function getSignedUrl(bucketName, method, params) {
   });
 }
 
-/**
- * Use AWS SDK to create pre-signed POST data.
- * We also put a default file size limit (100B - 10MB).
- * @param bucketName
- * @param key
- * @param contentType
- * @param expireTime
- * @param fileMinSize
- * @param fileMaxSize
- * @returns {Promise<object>}
- */
-function createPresignedPost({
-  bucketName,
-  key,
-  contentType,
-  expireTime,
-  fileMinSize = 10,
-  fileMaxSize = 10000000,
-}) {
-  const params = {
-    Expires: expireTime,
-    Bucket: bucketName,
-    Conditions: [['content-length-range', fileMinSize, fileMaxSize]], // 100Byte - 10MB
-    Fields: {
-      'Content-Type': contentType,
-      key,
-    },
-  };
-  return new Promise((resolve, reject) => {
-    s3Client.createPresignedPost(params, (err, data) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(data);
-    });
-  });
-}
-
 export default {
   getSignedUrl,
-  createPresignedPost,
 };

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -1,6 +1,6 @@
-import * as AWS from 'aws-sdk';
+import AWS from 'aws-sdk';
 
-const s3Client = new AWS.S3({ region: 'eu-north-1' });
+const s3Client = new AWS.S3();
 
 async function getSignedUrl(bucket, method, params) {
   return s3Client.getSignedUrl(method, {

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -2,9 +2,16 @@ import S3 from 'aws-sdk/clients/s3';
 
 const s3Client = new S3();
 
-async function getSignedUrl(bucket, method, params) {
+/**
+ * Use AWS SDK to create pre-signed upload url.
+ * @param bucketName
+ * @param method
+ * @param params
+ * @returns {string}
+ */
+async function getSignedUrl(bucketName, method, params) {
   return s3Client.getSignedUrl(method, {
-    Bucket: bucket,
+    Bucket: bucketName,
     ...params,
   });
 }

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -1,6 +1,6 @@
-import AWS from 'aws-sdk';
+import S3 from 'aws-sdk/clients/s3';
 
-const s3Client = new AWS.S3();
+const s3Client = new S3();
 
 async function getSignedUrl(bucket, method, params) {
   return s3Client.getSignedUrl(method, {
@@ -9,8 +9,46 @@ async function getSignedUrl(bucket, method, params) {
   });
 }
 
-const S3 = {
-  getSignedUrl,
-};
+/**
+ * Use AWS SDK to create pre-signed POST data.
+ * We also put a default file size limit (100B - 10MB).
+ * @param bucketName
+ * @param key
+ * @param contentType
+ * @param expireTime
+ * @param fileMinSize
+ * @param fileMaxSize
+ * @returns {Promise<object>}
+ */
+function createPresignedPost({
+  bucketName,
+  key,
+  contentType,
+  expireTime,
+  fileMinSize = 10,
+  fileMaxSize = 10000000,
+}) {
+  const params = {
+    Expires: expireTime,
+    Bucket: bucketName,
+    Conditions: [['content-length-range', fileMinSize, fileMaxSize]], // 100Byte - 10MB
+    Fields: {
+      'Content-Type': contentType,
+      key,
+    },
+  };
+  return new Promise((resolve, reject) => {
+    s3Client.createPresignedPost(params, (err, data) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(data);
+    });
+  });
+}
 
-export default S3;
+export default {
+  getSignedUrl,
+  createPresignedPost,
+};

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -1,0 +1,16 @@
+import * as AWS from 'aws-sdk';
+
+const s3Client = new AWS.S3({ region: 'eu-north-1' });
+
+async function getSignedUrl(bucket, method, params) {
+  return s3Client.getSignedUrl(method, {
+    Bucket: bucket,
+    ...params,
+  });
+}
+
+const S3 = {
+  getSignedUrl,
+};
+
+export default S3;

--- a/services/user-api/lambdas/getAttachments.js
+++ b/services/user-api/lambdas/getAttachments.js
@@ -1,0 +1,12 @@
+import * as response from '../../../libs/response';
+
+/**
+ * Get the user with the personal number specified in the path
+ */
+export const main = async () =>
+  response.buildResponse(200, {
+    type: 'userAttachments',
+    attributes: {
+      message: 'cool kid',
+    },
+  });

--- a/services/user-api/lambdas/uploadAttachments.js
+++ b/services/user-api/lambdas/uploadAttachments.js
@@ -1,0 +1,39 @@
+import * as response from '../../../libs/response';
+import S3 from '../../../libs/S3';
+import { v4 as uuid } from 'uuid';
+import { throwError, BadRequestError } from '@helsingborg-stad/npm-api-error-handling';
+import { decodeToken } from '../../../libs/token';
+
+// File formats that we accept.
+const allowedMimes = ['image/jpeg', 'image/png', 'image/jpg'];
+
+/**
+ * Get the user with the personal number specified in the path
+ */
+export async function main(event) {
+  const decodedToken = decodeToken(event);
+
+  const { body } = event;
+  const jsonData = JSON.parse(body);
+  if (!allowedMimes.includes(body.mime)) {
+    return response.failure(new BadRequestError(`The mimeType ${body.mime} is not allowed`));
+  }
+
+  const s3Key = `${decodedToken.personalNumber}/${body.fileName}`;
+
+  const params = {
+    ContentType: jsonData.mime,
+    ACL: 'public-read',
+    Key: s3Key,
+    Expires: 60 * 10,
+  };
+
+  const uploadUrl = await S3.getSignedUrl('hbg-attachments', 'putObject', params);
+
+  return response.success(200, {
+    type: 'userAttachment',
+    attributes: {
+      uploadUrl,
+    },
+  });
+}

--- a/services/user-api/lambdas/uploadAttachments.js
+++ b/services/user-api/lambdas/uploadAttachments.js
@@ -1,4 +1,5 @@
 import to from 'await-to-js';
+import { v4 as uuid } from 'uuid';
 import S3 from '../../../libs/S3';
 import * as response from '../../../libs/response';
 import { BadRequestError } from '@helsingborg-stad/npm-api-error-handling';
@@ -31,26 +32,37 @@ export async function main(event) {
   }
 
   // TODO: Decide the filename convention when generating a url.
-  // TODO: Check if filename can be set to a random id despite the name of the upload file from client.
-  // The path to where we want to upload a file in the s3 bucket.
-  const s3Key = `${decodedToken.personalNumber}/${fileName}`;
 
-  // TODO: Check if we can set a file size limit in these params.
+  // The path to where we want to upload a file in the s3 bucket.
+  const s3Key = `${decodedToken.personalNumber}/${uuid()}_${fileName}`;
+
+  // // TODO: Check if we can set a file size limit in these params.
+  // const params = {
+  //   ContentType: mime,
+  //   ACL: 'public-read',
+  //   Key: s3Key,
+  //   Expires: 60 * 10,
+  // };
+
   const params = {
-    ContentType: mime,
-    ACL: 'public-read',
-    Key: s3Key,
-    Expires: 60 * 10,
+    bucketName: 'hbg-attachments',
+    key: s3Key,
+    contentType: mime,
+    expireTime: 60,
   };
 
   // Request pre signed upload url from aws s3.
-  const [error, uploadUrl] = await to(S3.getSignedUrl('hbg-attachments', 'putObject', params));
+  const [error, uploadUrl] = await to(S3.createPresignedPost(params));
   if (error) return response.failure(error);
+
+  // // Request pre signed upload url from aws s3.
+  // const [error, uploadUrl] = await to(S3.getSignedUrl('hbg-attachments', 'putObject', params));
+  // if (error) return response.failure(error);
 
   return response.success(200, {
     type: 'userAttachment',
     attributes: {
-      uploadUrl,
+      ...uploadUrl,
     },
   });
 }

--- a/services/user-api/lambdas/uploadAttachments.js
+++ b/services/user-api/lambdas/uploadAttachments.js
@@ -44,7 +44,9 @@ export async function main(event) {
   };
 
   // Request pre signed upload url from aws s3.
-  const [error, uploadUrl] = await to(S3.getSignedUrl('hbg-attachments', 'putObject', params));
+  const [error, uploadUrl] = await to(
+    S3.getSignedUrl(process.env.BUCKET_NAME, 'putObject', params)
+  );
   if (error) return response.failure(error);
 
   return response.success(200, {

--- a/services/user-api/lambdas/uploadAttachments.js
+++ b/services/user-api/lambdas/uploadAttachments.js
@@ -1,5 +1,6 @@
-import * as response from '../../../libs/response';
+import to from 'await-to-js';
 import S3 from '../../../libs/S3';
+import * as response from '../../../libs/response';
 import { BadRequestError } from '@helsingborg-stad/npm-api-error-handling';
 import { decodeToken } from '../../../libs/token';
 
@@ -10,18 +11,31 @@ const allowedMimes = ['image/jpeg', 'image/png', 'image/jpg'];
  * Get the user with the personal number specified in the path
  */
 export async function main(event) {
-  // eslint-disable-next-line no-console
   const decodedToken = decodeToken(event);
 
   const { fileName, mime } = JSON.parse(event.body);
 
+  if (!fileName) {
+    // Check if fileName exsits in event body
+    return response.failure(new BadRequestError('Could not find key "fileName" in request body'));
+  }
+
+  if (!mime) {
+    // Check if mimeType exists in event body.
+    return response.failure(new BadRequestError('Could not find key "mime" in request body'));
+  }
+
   if (!allowedMimes.includes(mime)) {
+    // Check if passed mimeType is a fileformat that we allow.
     return response.failure(new BadRequestError(`The mimeType ${mime} is not allowed`));
   }
 
   // TODO: Decide the filename convention when generating a url.
+  // TODO: Check if filename can be set to a random id despite the name of the upload file from client.
+  // The path to where we want to upload a file in the s3 bucket.
   const s3Key = `${decodedToken.personalNumber}/${fileName}`;
 
+  // TODO: Check if we can set a file size limit in these params.
   const params = {
     ContentType: mime,
     ACL: 'public-read',
@@ -29,13 +43,14 @@ export async function main(event) {
     Expires: 60 * 10,
   };
 
-  const uploadUrl = await S3.getSignedUrl('hbg-attachments', 'putObject', params);
+  // Request pre signed upload url from aws s3.
+  const [error, uploadUrl] = await to(S3.getSignedUrl('hbg-attachments', 'putObject', params));
+  if (error) return response.failure(error);
 
   return response.success(200, {
     type: 'userAttachment',
     attributes: {
       uploadUrl,
-      filePath: s3Key,
     },
   });
 }

--- a/services/user-api/serverless.yml
+++ b/services/user-api/serverless.yml
@@ -43,6 +43,15 @@ provider:
       Resource:
         - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
 
+    - Effect: Allow
+      Action:
+        - s3:PutObject
+        - s3:PutObjectAcl
+        - s3:ListObject
+        - s3:GetObject
+      Resource:
+        - "Fn::ImportValue": ${self:custom.resourcesStage}-AttachementsBucketArn
+
 functions:
   get:
     handler: lambdas/get.main
@@ -61,6 +70,28 @@ functions:
       - http:
           path: /users/me
           method: get
+          cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId
+
+  getAttachements:
+    handler: lambdas/getAttachments.main
+    events:
+      - http:
+          path: /users/me/attachments
+          method: get
+          cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId
+
+  uploadAttachements:
+    handler: lambdas/uploadAttachments.main
+    events:
+      - http:
+          path: /users/me/attachments
+          method: post
           cors: true
           authorizer:
             type: CUSTOM

--- a/services/user-api/serverless.yml
+++ b/services/user-api/serverless.yml
@@ -50,10 +50,10 @@ provider:
         - s3:ListObject
         - s3:GetObject
       Resource:
-        - Fn::ImportValue: ${self:custom.resourcesStage}-AttachementsBucketArn
+        - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
         - Fn::Join:
             - ""
-            - - Fn::ImportValue: ${self:custom.resourcesStage}-AttachementsBucketArn
+            - - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
               - "/*"
 
 functions:
@@ -92,6 +92,8 @@ functions:
 
   uploadAttachements:
     handler: lambdas/uploadAttachments.main
+    environment:
+      BUCKET_NAME: !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
     events:
       - http:
           path: /users/me/attachments

--- a/services/user-api/serverless.yml
+++ b/services/user-api/serverless.yml
@@ -50,7 +50,11 @@ provider:
         - s3:ListObject
         - s3:GetObject
       Resource:
-        - "Fn::ImportValue": ${self:custom.resourcesStage}-AttachementsBucketArn
+        - Fn::ImportValue: ${self:custom.resourcesStage}-AttachementsBucketArn
+        - Fn::Join:
+            - ""
+            - - Fn::ImportValue: ${self:custom.resourcesStage}-AttachementsBucketArn
+              - "/*"
 
 functions:
   get:


### PR DESCRIPTION
Before there was no way to upload images to AWS S3 through the api gateway.

This PR makes it possible to request a pre signed upload url that can be used in a client to do direct uploads towards a bucket in AWS S3.

This PR does support any type of file sizes to be uploaded, which will need to be solved in a future implementation.

NOTE: To test this PR you need to setup the attachments bucket that are found in the resources repo, otherwise the added attachments endpoint will not work.

Test this PR

** 1. Send a POST request towards the endpoint users/me/attachments with the following body:**
`{ 
    "fileName": "somefilename", 
    "mime": "image/jpg" // (could also be /png or /jpeg)
}`
This will grant you a response with a pre signed upload url.

** 2. Upload a file with the url**
Send a PUT request towards the pre signed URL, in the request body you will need to attach a binary file that matches the mime that you earlier entered to obtain the pre signed url

** 3. Check for file in S3**
The last step you will need to do is to check if the file have been uploaded, this can be done through the aws management console at aws.amazon.com-
