### PR TITLE
fix(case): rename current-step to current-position

### DIFF
--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -16,7 +16,7 @@ export async function main(event) {
   const requestBody = JSON.parse(event.body);
   const { id } = event.pathParameters;
 
-  const { provider, formId, currentStep, status, details, answers } = requestBody;
+  const { provider, formId, currentPosition, status, details, answers } = requestBody;
 
   let UpdateExpression = 'SET #updated = :updated';
   const ExpressionAttributeNames = { '#updated': 'updatedAt' };
@@ -34,10 +34,10 @@ export async function main(event) {
     ExpressionAttributeValues[':newFormId'] = formId;
   }
 
-  if (currentStep) {
-    UpdateExpression += ', #currentStep = :newStep';
-    ExpressionAttributeNames['#currentStep'] = 'currentStep';
-    ExpressionAttributeValues[':newStep'] = currentStep;
+  if (currentPosition) {
+    UpdateExpression += ', #currentPosition = :newPosition';
+    ExpressionAttributeNames['#currentPosition'] = 'currentPosition';
+    ExpressionAttributeValues[':newPosition'] = currentPosition;
   }
 
   if (status) {


### PR DESCRIPTION
A renaming of a variable to reflect a change in the data we store: currentStep used to be a number, now it's a larger position object. 