### PR TITLE
Fix/revert create case schema to work with current app

### DIFF
--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -21,6 +21,12 @@ const caseValidationSchema = Joi.object({
   formId: uuid.required(),
   provider: caseProvider.required(),
   answers: caseAnswers.allow(),
+  currentPosition: Joi.object({
+    index: Joi.number().required(),
+    level: Joi.number().required(),
+    currentMainStep: Joi.number().required(),
+    currentMainStepIndex: Joi.number().required(),
+  }),
 });
 
 export default caseValidationSchema;

--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -10,7 +10,7 @@ const caseProvider = Joi.string().valid(CASE_PROVIDER_VIVA);
 const caseAnswers = Joi.array().items(
   Joi.object({
     field: Joi.object({
-      id: uuid.required(),
+      id: Joi.string().required(),
       tags: Joi.array().items(Joi.string()).required(),
     }).required(),
     value: Joi.string().required(),

--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -27,6 +27,7 @@ const caseValidationSchema = Joi.object({
     currentMainStep: Joi.number().required(),
     currentMainStepIndex: Joi.number().required(),
   }),
+  details: Joi.object().allow(),
 });
 
 export default caseValidationSchema;

--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -32,7 +32,7 @@ export async function main(event) {
 
   // TODO: check if the passed formId exsists in the form dynamo table.
 
-  const { formId, provider, ...rest } = validatedEventBody;
+  const { formId, provider, details, answers, currentPosition } = validatedEventBody;
   const { personalNumber } = decodedToken;
   const id = uuid.v4();
   const PK = `USER#${personalNumber}`;
@@ -48,11 +48,11 @@ export async function main(event) {
     updatedAt: timestamp,
     expirationTime,
     status: CASE_STATUS_ONGOING,
-    details: {},
-    answers: [],
     formId,
     provider,
-    ...rest,
+    details,
+    answers,
+    currentPosition,
   };
 
   const putItemParams = {


### PR DESCRIPTION
We update the case schema so that it works with what we send from the app. The previous schema was too strict, so it did not accept what the app was sending. 

In the future, we want to change more things in the app (mainly the field ids should be uuid, and the current id should be renamed to valueReference or something along these lines), but for now, we will adjust the schema so that things at least work. 