### PR TITLE
fix(case-schema): more permissive answer value type

### DIFF
--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -13,7 +13,7 @@ const caseAnswers = Joi.array().items(
       id: Joi.string().required(),
       tags: Joi.array().items(Joi.string()).required(),
     }).required(),
-    value: Joi.string().required(),
+    value: Joi.any(),
   })
 );
 


### PR DESCRIPTION
The requirement that the answer values are only strings is way too strict. For now, to get the app to work for test flight users, I change it to be very permissive, but later we have to figure this out. But at least numbers and booleans should be permitted, or we should implement a standardized way to stringify our values.