### PR TITLE
Feat/renew access token

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,16 +4,20 @@ const resourcesStage = process.env.resourcesStage;
 
 const stageConfigs = {
   dev: {
-    authorization_code: {
-      secret: {
-        keyName: 'AuthorizationCodeGrantSecret',
-        name: 'dev/authorizationCodeGrant/secret',
-      },
-    },
-    token: {
-      secret: {
-        keyName: 'TokenGeneratorSecret',
-        name: 'dev/token/generation',
+    auth: {
+      secrets: {
+        accessToken: {
+          keyName: 'AccessTokenSecret',
+          name: 'dev/token/access/secret',
+        },
+        refreshToken: {
+          keyName: 'RefreshTokenSecret',
+          name: 'dev/token/refresh/secret',
+        },
+        authorizationCode: {
+          keyName: 'AuthorizationCodeSecret',
+          name: 'dev/token/authorization/code/secret',
+        },
       },
     },
     bankId: {

--- a/config.js
+++ b/config.js
@@ -4,6 +4,12 @@ const resourcesStage = process.env.resourcesStage;
 
 const stageConfigs = {
   dev: {
+    authorization_code: {
+      secret: {
+        keyName: 'AuthorizationCodeGrantSecret',
+        name: 'dev/authorizationCodeGrant/secret',
+      },
+    },
     token: {
       secret: {
         keyName: 'TokenGeneratorSecret',

--- a/libs/token.js
+++ b/libs/token.js
@@ -1,5 +1,4 @@
 import jwt from 'jsonwebtoken';
-// import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 
 /**
  * Takes an http event with an jwt authorization header, and returns the decoded info from it. Does not check if the token is valid, that should be handled by an authorizer.
@@ -22,10 +21,10 @@ export function decodeToken(httpEvent) {
  * @param {string} secret the secret key to sign the JSON Web Token.
  * @param {number} expireTimeInSeconds the expire time for the token in seconds.
  */
-export async function signToken(jsonToSign, secret, expireTimeInSeconds) {
+export async function signToken(jsonToSign, secret, expireTimeInMinutes) {
   // Add expiration time to JWT token.
   // The format is in seconds since Jan 1, 1970, not milliseconds, to match the default iat format of JWT.
-  jsonToSign.exp = parseInt(Date.now() / 1000) + expireTimeInSeconds * 60;
+  jsonToSign.exp = parseInt(Date.now() / 1000) + expireTimeInMinutes * 60;
 
   const token = jwt.sign(jsonToSign, secret);
   return token;

--- a/services/auth/token/helpers/schema.js
+++ b/services/auth/token/helpers/schema.js
@@ -1,6 +1,8 @@
 import Joi from 'joi';
 
-const jwt = Joi.string().regex(/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/=]*$/);
+// regex for matching a json web token string pattern (xxxx.xxxx.xxxx)
+const matchJsonWebToken = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/=]*$/;
+const jwt = Joi.string().regex(matchJsonWebToken);
 
 const tokenValidationSchema = Joi.object({
   grant_type: Joi.string().valid('authorization_code', 'refresh_token').required(),

--- a/services/auth/token/helpers/schema.js
+++ b/services/auth/token/helpers/schema.js
@@ -1,0 +1,19 @@
+import Joi from 'joi';
+
+const jwt = Joi.string().regex(/^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_.+/=]*$/);
+
+const tokenValidationSchema = Joi.object({
+  grant_type: Joi.string().valid('authorization_code', 'refresh_token').required(),
+  code: jwt.when('grant_type', {
+    is: 'authorization_code',
+    then: Joi.required(),
+    otherwise: Joi.optional(),
+  }),
+  refresh_token: jwt.when('grant_type', {
+    is: 'refresh_token',
+    then: Joi.required(),
+    otherwise: Joi.optional(),
+  }),
+});
+
+export default tokenValidationSchema;

--- a/services/auth/token/lambdas/authorize.js
+++ b/services/auth/token/lambdas/authorize.js
@@ -2,6 +2,10 @@ import to from 'await-to-js';
 
 import generateIAMPolicy from '../helpers/generateIAMPolicy';
 import { verifyToken } from '../../../../libs/token';
+import config from '../../../../config';
+import secrets from '../../../../libs/secrets';
+
+const CONFIG_AUTH_SECRETS_ACCESS_TOKEN = config.auth.secrets.accessToken;
 
 export async function main(event) {
   const { authorizationToken } = event;
@@ -10,7 +14,14 @@ export async function main(event) {
     ? authorizationToken.substr(authorizationToken.indexOf(' ') + 1)
     : authorizationToken;
 
-  const [error, decodedToken] = await to(verifyToken(token));
+  const [getSecretError, secret] = await to(
+    secrets.get(CONFIG_AUTH_SECRETS_ACCESS_TOKEN.name, CONFIG_AUTH_SECRETS_ACCESS_TOKEN.keyName)
+  );
+  if (getSecretError) {
+    throw Error('Unauthorized');
+  }
+
+  const [error, decodedToken] = await to(verifyToken(token, secret));
   if (error) {
     // By thorwing this error AWS returns a 401 response with the message unauthorized
     throw Error('Unauthorized');

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -96,12 +96,12 @@ async function validateToken(secretConfig, token) {
  * @param {object} params an object consiting of key/value pairs for query string parameters.
  */
 async function validateAutorizationQueryStringParams(params) {
-  const valid_grant_types = ['refresh_token', 'authorization_code'];
+  const validGrantTypes = ['refresh_token', 'authorization_code'];
 
   if (params === null || !params.grant_type) {
     throwError(400, 'Missing request param grant_type');
   }
-  if (!valid_grant_types.includes(params.grant_type)) {
+  if (!validGrantTypes.includes(params.grant_type)) {
     throwError(400, 'Incorrect grant_type is passed in request params');
   }
   if (params.grant_type === 'authorization_code' && !params.code) {

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -9,7 +9,7 @@ const authSecrets = config.auth.secrets;
 
 export const main = async event => {
   const [queryStringParamsError, queryStringParams] = await to(
-    validateAutorizationQueryStringParams(event.queryStringParameters)
+    validateAuthorizationQueryStringParams(event.queryStringParameters)
   );
   if (queryStringParamsError) return response.failure(queryStringParamsError);
 
@@ -95,7 +95,7 @@ async function validateToken(secretConfig, token) {
  * Function for validating query paramaters for authorization
  * @param {object} params an object consiting of key/value pairs for query string parameters.
  */
-async function validateAutorizationQueryStringParams(params) {
+async function validateAuthorizationQueryStringParams(params) {
   const validGrantTypes = ['refresh_token', 'authorization_code'];
 
   if (params === null || !params.grant_type) {

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -66,13 +66,13 @@ function getGrantTypeDetails(queryStringParams) {
   }
 }
 
-async function generateToken(secretConfig, personalNumber, expiresInSeconds) {
+async function generateToken(secretConfig, personalNumber, expiresInMinutes) {
   const [getSecretError, secret] = await to(secrets.get(secretConfig.name, secretConfig.keyName));
   if (getSecretError) {
     throwError(getSecretError.code, getSecretError.message);
   }
 
-  const [signTokenError, token] = await to(signToken({ personalNumber }, secret, expiresInSeconds));
+  const [signTokenError, token] = await to(signToken({ personalNumber }, secret, expiresInMinutes));
   if (signTokenError) throwError(401, signTokenError.message);
 
   return token;

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -6,6 +6,8 @@ import { signToken, verifyToken } from '../../../../libs/token';
 import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 
 const CONFIG_AUTH_SECRETS = config.auth.secrets;
+const ACCESS_TOKEN_EXPIRES_IN_MINUTES = 20;
+const REFRESH_TOKEN_EXPIRES_IN_MINUTES = 30;
 
 export const main = async event => {
   const [queryStringParamsError, queryStringParams] = await to(
@@ -26,17 +28,19 @@ export const main = async event => {
 
   const personalNumber = decodedGrantToken.personalNumber;
 
-  const accessTokenExpiresInMinutes = 20;
   const [getAccessTokenError, accessToken] = await to(
-    generateToken(CONFIG_AUTH_SECRETS.accessToken, personalNumber, accessTokenExpiresInMinutes)
+    generateToken(CONFIG_AUTH_SECRETS.accessToken, personalNumber, ACCESS_TOKEN_EXPIRES_IN_MINUTES)
   );
   if (getAccessTokenError) {
     return response.failure(getAccessTokenError);
   }
 
-  const refreshTokenExpiresInMinutes = 30;
   const [getRefreshTokenError, refreshToken] = await to(
-    generateToken(CONFIG_AUTH_SECRETS.refreshToken, personalNumber, refreshTokenExpiresInMinutes)
+    generateToken(
+      CONFIG_AUTH_SECRETS.refreshToken,
+      personalNumber,
+      REFRESH_TOKEN_EXPIRES_IN_MINUTES
+    )
   );
   if (getRefreshTokenError) {
     return response.failure(getRefreshTokenError);

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -17,10 +17,10 @@ export const main = async event => {
     return response.failure(queryStringParamsError);
   }
 
-  const grantTypeDetails = getGrantTypeDetails(queryStringParams);
+  const grantTypeValues = getGrantTypeValues(queryStringParams);
 
   const [validateTokenError, decodedGrantToken] = await to(
-    validateToken(grantTypeDetails.secretsConfig, grantTypeDetails.token)
+    validateToken(grantTypeValues.secretsConfig, grantTypeValues.token)
   );
   if (validateTokenError) {
     return response.failure(validateTokenError);
@@ -56,7 +56,7 @@ export const main = async event => {
   return response.success(200, successResponsePayload);
 };
 
-function getGrantTypeDetails(queryStringParams) {
+function getGrantTypeValues(queryStringParams) {
   if (queryStringParams.grant_type === 'authorization_code') {
     return {
       secretsConfig: CONFIG_AUTH_SECRETS.authorizationCode,

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -65,7 +65,9 @@ export const main = async event => {
 async function validateEventBody(eventBody, schema) {
   const { error, value } = schema.validate(eventBody, { abortEarly: false });
   if (error) {
-    throwError(400, error.message.replace(/"/g, "'"));
+    const matchDoubleQuote = /"/g;
+    const singleQuote = "'";
+    throwError(400, error.message.replace(matchDoubleQuote, singleQuote));
   }
 
   return value;

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -5,7 +5,7 @@ import * as response from '../../../../libs/response';
 import { signToken, verifyToken } from '../../../../libs/token';
 import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 
-const authSecrets = config.auth.secrets;
+const CONFIG_AUTH_SECRETS = config.auth.secrets;
 
 export const main = async event => {
   const [queryStringParamsError, queryStringParams] = await to(
@@ -26,7 +26,7 @@ export const main = async event => {
 
   const accessTokenExpiresInMinutes = 20;
   const [getAccessTokenError, accessToken] = await to(
-    generateToken(authSecrets.accessToken, personalNumber, accessTokenExpiresInMinutes)
+    generateToken(CONFIG_AUTH_SECRETS.accessToken, personalNumber, accessTokenExpiresInMinutes)
   );
   if (getAccessTokenError) {
     return response.failure(getAccessTokenError);
@@ -34,7 +34,7 @@ export const main = async event => {
 
   const refreshTokenExpiresInMinutes = 30;
   const [getRefreshTokenError, refreshToken] = await to(
-    generateToken(authSecrets.refreshToken, personalNumber, refreshTokenExpiresInMinutes)
+    generateToken(CONFIG_AUTH_SECRETS.refreshToken, personalNumber, refreshTokenExpiresInMinutes)
   );
   if (getRefreshTokenError) {
     return response.failure(getRefreshTokenError);
@@ -53,14 +53,14 @@ export const main = async event => {
 function getGrantTypeDetails(queryStringParams) {
   if (queryStringParams.grant_type === 'authorization_code') {
     return {
-      secretsConfig: authSecrets.authorizationCode,
+      secretsConfig: CONFIG_AUTH_SECRETS.authorizationCode,
       token: queryStringParams.code,
     };
   }
 
   if (queryStringParams.grant_type === 'refresh_token') {
     return {
-      secretsConfig: authSecrets.refreshToken,
+      secretsConfig: CONFIG_AUTH_SECRETS.refreshToken,
       token: queryStringParams.refresh_token,
     };
   }

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -11,7 +11,9 @@ export const main = async event => {
   const [queryStringParamsError, queryStringParams] = await to(
     validateQueryStringParams(event.queryStringParameters)
   );
-  if (queryStringParamsError) return response.failure(queryStringParamsError);
+  if (queryStringParamsError) {
+    return response.failure(queryStringParamsError);
+  }
 
   const grantTypeDetails = getGrantTypeDetails(queryStringParams);
 
@@ -73,7 +75,9 @@ async function generateToken(secretConfig, personalNumber, expiresInMinutes) {
   }
 
   const [signTokenError, token] = await to(signToken({ personalNumber }, secret, expiresInMinutes));
-  if (signTokenError) throwError(401, signTokenError.message);
+  if (signTokenError) {
+    throwError(401, signTokenError.message);
+  }
 
   return token;
 }

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -91,10 +91,6 @@ async function validateToken(secretConfig, token) {
   return verifiedToken;
 }
 
-/**
- * Function for validating query paramaters for authorization
- * @param {object} params an object consiting of key/value pairs for query string parameters.
- */
 async function validateAuthorizationQueryStringParams(params) {
   const validGrantTypes = ['refresh_token', 'authorization_code'];
 

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -11,13 +11,13 @@ const ACCESS_TOKEN_EXPIRES_IN_MINUTES = 20;
 const REFRESH_TOKEN_EXPIRES_IN_MINUTES = 30;
 
 export const main = async event => {
-  const [parseJsonError, parsedJsonData] = await to(parseJsonData(event.body));
+  const [parseJsonError, parsedJson] = await to(parseJson(event.body));
   if (parseJsonError) {
     return response.failure(parseJsonError);
   }
 
   const [validationError, validatedEventBody] = await to(
-    validateEventBody(parsedJsonData, tokenValidationSchema)
+    validateEventBody(parsedJson, tokenValidationSchema)
   );
   if (validationError) {
     return response.failure(validationError);
@@ -71,9 +71,9 @@ async function validateEventBody(eventBody, schema) {
   return value;
 }
 
-async function parseJsonData(data) {
+async function parseJson(eventBody) {
   try {
-    const parsedJsonData = JSON.parse(data);
+    const parsedJsonData = JSON.parse(eventBody);
     return parsedJsonData;
   } catch (error) {
     throwError(400, error.message);

--- a/services/auth/token/lambdas/generateToken.js
+++ b/services/auth/token/lambdas/generateToken.js
@@ -9,7 +9,7 @@ const authSecrets = config.auth.secrets;
 
 export const main = async event => {
   const [queryStringParamsError, queryStringParams] = await to(
-    validateAuthorizationQueryStringParams(event.queryStringParameters)
+    validateQueryStringParams(event.queryStringParameters)
   );
   if (queryStringParamsError) return response.failure(queryStringParamsError);
 
@@ -91,7 +91,7 @@ async function validateToken(secretConfig, token) {
   return verifiedToken;
 }
 
-async function validateAuthorizationQueryStringParams(params) {
+async function validateQueryStringParams(params) {
   const validGrantTypes = ['refresh_token', 'authorization_code'];
 
   if (params === null || !params.grant_type) {

--- a/services/auth/token/serverless.yml
+++ b/services/auth/token/serverless.yml
@@ -50,6 +50,12 @@ functions:
           method: post
           cors: true
           private: true
+          request:
+            parameters:
+              querystrings:
+                grant_type: true
+                refresh_token: true
+                code: true
 
 resources:
   Resources:

--- a/services/auth/token/serverless.yml
+++ b/services/auth/token/serverless.yml
@@ -50,12 +50,6 @@ functions:
           method: post
           cors: true
           private: true
-          request:
-            parameters:
-              querystrings:
-                grant_type: true
-                refresh_token: true
-                code: true
 
 resources:
   Resources:


### PR DESCRIPTION
## Explain the changes you’ve made

Support for variants of OAuth 2 Authorization Code Grant and Refresh Token Grant standards for obtaining tokens.

## Explain why these changes are made
The reason behind these changes are a need for clients to extend sessions by obtaining a new access token. This was currently not supported in the authorization/authentication flow provided by the api.

## Explain your solution
This new solution for obtaining tokens are dependent on what Oauth calls grant types. In order to specifiy a grant type and other params that needs to be passed query string params are used. The query string parameters passed with the request are then validated on the passed gran type and additional required params for that specific grant type. The solution currently supports two grant types authorization_code and refresh_token. 

Example of authorization_code grant: 
```?grant_type=authorization_code&code=valid_authorization_code```.
A valid authorization code can be obtained in the payload after a successfull login with bankid.

Example of refresh_token grant: 
```?grant_type=refresh_token&refresh_token=valid_refresh_token```.

Both grant types returns a response containing a pair of access and refresh token.

## How to test the changes?

In order to test these changes you will first need to add the appropriate secrets in AWS secrets manager. The naming of the secrets can be found in the config.js


*Test authorization code grant:*
1. create a token that has minimum payload of personalNumber and sign it with the authorization code secret defined in aws secrets manager. I suggest that you use jwt.io to generate a signed token.
2. Make a post request to ```https://your_aws_env_url/dev/auth/token?grant_type=authorization_code&code=the_signed_jwt_token_you_created``` with the x-api-key header set to your api-key
3. Upon successful response you should have a access token and a refresh token.
4. Copy the refresh_token, you will need it to test the refresh_token grant.

Test refresh token grant:
1. Make a post request to ```https://your_aws_env_url/dev/auth/token?grant_type=refresh_token&refresh_token=valid_refresh_token```  with the x-api-key header set to your api-key
2. Successful response should contain a new pair of access and refresh token

## Additional notes
Changes will have to be made in the bankid service and the app in order to support this improved authorization/authentication flow.

To add extra security in this flow we can also add query params that verifies the client sending authorization request srequest, these can be done with the client_id and client_secret params defined in the Oauth documentation.