### PR TITLE
Feat/attachments delete

### DIFF
--- a/libs/S3.js
+++ b/libs/S3.js
@@ -1,6 +1,6 @@
 import S3 from 'aws-sdk/clients/s3';
 
-const s3Client = new S3();
+export const s3Client = new S3();
 
 /**
  * Use AWS SDK to create pre-signed upload url.

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@types/node": "^14.14.9",
     "@typescript-eslint/parser": "^4.11.1",
+    "@types/aws-lambda": "^8.10.70",
+    "@types/node": "^14.14.21",
     "babel-eslint": "^10.1.0",
     "commitizen": "^4.2.2",
     "commitlint": "^11.0.0",
@@ -52,6 +53,7 @@
   "dependencies": {
     "@helsingborg-stad/npm-api-error-handling": "^0.15.0",
     "await-to-js": "^2.1.1",
+    "aws-lambda": "^1.0.6",
     "aws-sdk": "^2.797.0",
     "axios": "^0.21.1",
     "camelcase": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@typescript-eslint/parser": "^4.11.1",
     "@types/aws-lambda": "^8.10.70",
     "@types/node": "^14.14.21",
+    "@typescript-eslint/parser": "^4.13.0",
     "babel-eslint": "^10.1.0",
     "commitizen": "^4.2.2",
     "commitlint": "^11.0.0",

--- a/services/users-api/lambdas/deleteAttachment.ts
+++ b/services/users-api/lambdas/deleteAttachment.ts
@@ -1,7 +1,6 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { s3Client } from '../../../libs/S3';
 import { buildResponse } from '../../../libs/response';
-import * as response from '../../../libs/response';
 import { decodeToken } from '../../../libs/token';
 
 const bucketName = process.env.BUCKET_NAME;
@@ -12,11 +11,12 @@ export const main = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxy
   const { personalNumber } = decodedToken as { personalNumber: string };
 
   if (!filename) {
-    return response.failure(
-      buildResponse(400, { message: 'Need a filename as part of the path.' })
-    );
+    return buildResponse(400, {
+      type: 'userAttachment',
+      attributes: { message: 'Need a filename as part of the path.' },
+    });
   }
-  // The path to where the file is in the s3 bucket
+
   const s3Key = `${personalNumber}/${filename}`;
 
   // Check if the specified file exists in the bucket

--- a/services/users-api/lambdas/deleteAttachment.ts
+++ b/services/users-api/lambdas/deleteAttachment.ts
@@ -1,0 +1,40 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import S3, { s3Client } from '../../../libs/S3';
+import { buildResponse } from '../../../libs/response';
+import * as response from '../../../libs/response';
+import { decodeToken } from '../../../libs/token';
+import { DeleteObjectRequest } from 'aws-sdk/clients/s3';
+
+const bucketName = process.env.BUCKET_NAME; 
+
+export const main = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const decodedToken = decodeToken(event);
+  const { filename } = event.pathParameters;
+  const { personalNumber } = (decodedToken as {personalNumber: string});
+
+  if (!filename) {
+    return response.failure(buildResponse(400, { message: 'Need a filename as part of the path.'));
+  }
+  // The path to where the file is in the s3 bucket
+  const s3Key = `${personalNumber}/${filename}`;
+
+  const params: DeleteObjectRequest = {
+    Bucket: bucketName,
+    Key: s3Key,
+  };
+  
+  const deleteResponse = await s3Client.deleteObject(params).promise();
+
+  if (deleteResponse.$response.error) {
+    console.log('Delete error', deleteResponse.$response.error.message);
+    return response.failure(buildResponse(deleteResponse.$response.error.code, deleteResponse.$response.error.message))
+  }
+
+  return response.success(200, {
+    type: 'userAttachment',
+    attributes: {
+      type: 'file deleted',
+      awsResponse: deleteResponse.$response,
+    },
+  });
+};

--- a/services/users-api/lambdas/deleteAttachment.ts
+++ b/services/users-api/lambdas/deleteAttachment.ts
@@ -1,40 +1,73 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import S3, { s3Client } from '../../../libs/S3';
+import { s3Client } from '../../../libs/S3';
 import { buildResponse } from '../../../libs/response';
 import * as response from '../../../libs/response';
 import { decodeToken } from '../../../libs/token';
-import { DeleteObjectRequest } from 'aws-sdk/clients/s3';
 
-const bucketName = process.env.BUCKET_NAME; 
+const bucketName = process.env.BUCKET_NAME;
 
 export const main = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   const decodedToken = decodeToken(event);
   const { filename } = event.pathParameters;
-  const { personalNumber } = (decodedToken as {personalNumber: string});
+  const { personalNumber } = decodedToken as { personalNumber: string };
 
   if (!filename) {
-    return response.failure(buildResponse(400, { message: 'Need a filename as part of the path.'));
+    return response.failure(
+      buildResponse(400, { message: 'Need a filename as part of the path.' })
+    );
   }
   // The path to where the file is in the s3 bucket
   const s3Key = `${personalNumber}/${filename}`;
 
-  const params: DeleteObjectRequest = {
-    Bucket: bucketName,
-    Key: s3Key,
-  };
-  
-  const deleteResponse = await s3Client.deleteObject(params).promise();
-
-  if (deleteResponse.$response.error) {
-    console.log('Delete error', deleteResponse.$response.error.message);
-    return response.failure(buildResponse(deleteResponse.$response.error.code, deleteResponse.$response.error.message))
+  // Check if the specified file exists in the bucket
+  const listFilesResponse = await s3Client
+    .listObjectsV2({
+      Bucket: bucketName,
+      Prefix: `${personalNumber}/`,
+    })
+    .promise();
+  const fileInBucket = listFilesResponse.Contents.find(file => file?.Key === s3Key);
+  if (!fileInBucket) {
+    return buildResponse(404, {
+      type: 'userAttachment',
+      attributes: {
+        type: 'deleteError',
+        bucket: bucketName,
+        filename,
+        deletedFileKey: s3Key,
+        message: `No file with key '${s3Key}', filename '${filename}', exists in storage. Nothing was deleted.`,
+      },
+    });
   }
 
-  return response.success(200, {
+  const deleteResponse = await s3Client
+    .deleteObject({
+      Bucket: bucketName,
+      Key: s3Key,
+    })
+    .promise();
+
+  if (deleteResponse.$response.error) {
+    console.error('Delete error: ', deleteResponse.$response.error.message);
+    return buildResponse(deleteResponse.$response.error.code, {
+      type: 'userAttachment',
+      attributes: {
+        type: 'deleteError',
+        bucket: bucketName,
+        filename,
+        deletedFileKey: s3Key,
+        message: deleteResponse.$response.error.message,
+      },
+    });
+  }
+
+  return buildResponse(200, {
     type: 'userAttachment',
     attributes: {
-      type: 'file deleted',
-      awsResponse: deleteResponse.$response,
+      type: 'deleteSuccess',
+      bucket: bucketName,
+      filename,
+      deletedFileKey: s3Key,
     },
   });
 };

--- a/services/users-api/serverless.yml
+++ b/services/users-api/serverless.yml
@@ -49,6 +49,7 @@ provider:
         - s3:PutObjectAcl
         - s3:ListObject
         - s3:GetObject
+        - s3:DeleteObject
       Resource:
         - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
         - Fn::Join:

--- a/services/users-api/serverless.yml
+++ b/services/users-api/serverless.yml
@@ -102,3 +102,16 @@ functions:
           authorizer:
             type: CUSTOM
             authorizerId: !ImportValue ${self:custom.stage}-authorizerId
+
+  deleteAttachment:
+    handler: lambdas/deleteAttachment.main
+    environment:
+      BUCKET_NAME: !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
+    events:
+      - http:
+          path: /users/me/attachments/{filename}
+          method: delete
+          cors: true
+          authorizer:
+            type: CUSTOM
+            authorizerId: !ImportValue ${self:custom.stage}-authorizerId

--- a/services/users-api/tsconfig.json
+++ b/services/users-api/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2020",
+    "outDir": "build",
+    "alwaysStrict": false,
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "strictFunctionTypes": false,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,14 +1734,14 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^4.11.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.11.1.tgz#981e18de2e019d6ca312596615f92e8f6f6598ed"
-  integrity sha512-BJ3jwPQu1jeynJ5BrjLuGfK/UJu6uwHxJ/di7sanqmUmxzmyIcd3vz58PMR7wpi8k3iWq2Q11KMYgZbUpRoIPw==
+"@typescript-eslint/parser@^4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.13.0.tgz#c413d640ea66120cfcc37f891e8cb3fd1c9d247d"
+  integrity sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.11.1"
-    "@typescript-eslint/types" "4.11.1"
-    "@typescript-eslint/typescript-estree" "4.11.1"
+    "@typescript-eslint/scope-manager" "4.13.0"
+    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/typescript-estree" "4.13.0"
     debug "^4.1.1"
 
 "@typescript-eslint/parser@^4.5.0":
@@ -1754,13 +1754,13 @@
     "@typescript-eslint/typescript-estree" "4.8.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.11.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.11.1.tgz#72dc2b60b0029ab0888479b12bf83034920b4b69"
-  integrity sha512-Al2P394dx+kXCl61fhrrZ1FTI7qsRDIUiVSuN6rTwss6lUn8uVO2+nnF4AvO0ug8vMsy3ShkbxLu/uWZdTtJMQ==
+"@typescript-eslint/scope-manager@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz#5b45912a9aa26b29603d8fa28f5e09088b947141"
+  integrity sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==
   dependencies:
-    "@typescript-eslint/types" "4.11.1"
-    "@typescript-eslint/visitor-keys" "4.11.1"
+    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/visitor-keys" "4.13.0"
 
 "@typescript-eslint/scope-manager@4.8.1":
   version "4.8.1"
@@ -1770,23 +1770,23 @@
     "@typescript-eslint/types" "4.8.1"
     "@typescript-eslint/visitor-keys" "4.8.1"
 
-"@typescript-eslint/types@4.11.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.11.1.tgz#3ba30c965963ef9f8ced5a29938dd0c465bd3e05"
-  integrity sha512-5kvd38wZpqGY4yP/6W3qhYX6Hz0NwUbijVsX2rxczpY6OXaMxh0+5E5uLJKVFwaBM7PJe1wnMym85NfKYIh6CA==
+"@typescript-eslint/types@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.13.0.tgz#6a7c6015a59a08fbd70daa8c83dfff86250502f8"
+  integrity sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==
 
 "@typescript-eslint/types@4.8.1":
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.8.1.tgz#23829c73c5fc6f4fcd5346a7780b274f72fee222"
   integrity sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==
 
-"@typescript-eslint/typescript-estree@4.11.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.1.tgz#a4416b4a65872a48773b9e47afabdf7519eb10bc"
-  integrity sha512-tC7MKZIMRTYxQhrVAFoJq/DlRwv1bnqA4/S2r3+HuHibqvbrPcyf858lNzU7bFmy4mLeIHFYr34ar/1KumwyRw==
+"@typescript-eslint/typescript-estree@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.13.0.tgz#cf6e2207c7d760f5dfd8d18051428fadfc37b45e"
+  integrity sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==
   dependencies:
-    "@typescript-eslint/types" "4.11.1"
-    "@typescript-eslint/visitor-keys" "4.11.1"
+    "@typescript-eslint/types" "4.13.0"
+    "@typescript-eslint/visitor-keys" "4.13.0"
     debug "^4.1.1"
     globby "^11.0.1"
     is-glob "^4.0.1"
@@ -1808,12 +1808,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@4.11.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.1.tgz#4c050a4c1f7239786e2dd4e69691436143024e05"
-  integrity sha512-IrlBhD9bm4bdYcS8xpWarazkKXlE7iYb1HzRuyBP114mIaj5DJPo11Us1HgH60dTt41TCZXMaTCAW+OILIYPOg==
+"@typescript-eslint/visitor-keys@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz#9acb1772d3b3183182b6540d3734143dce9476fe"
+  integrity sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==
   dependencies:
-    "@typescript-eslint/types" "4.11.1"
+    "@typescript-eslint/types" "4.13.0"
     eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.8.1":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/aws-lambda@^8.10.70":
+  version "8.10.70"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.70.tgz#1d1c79730669b337208e3476f7a16150d43fcaf5"
+  integrity sha512-adaPn39OKMIzCxaf2KHBu4d3MJKLGdm27zxAyag+rAI1UTwgtgEgrwRpuzN1NDMZn/i6vRxJZRbsSmlw7I0/Sg==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -1662,10 +1667,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.8.tgz#2127bd81949a95c8b7d3240f3254352d72563aec"
   integrity sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==
 
-"@types/node@^14.14.9":
-  version "14.14.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"
-  integrity sha512-JsoLXFppG62tWTklIoO4knA+oDTYsmqWxHRvd4lpmfQRNhX6osheUOWETP2jMoV/2bEHuMra8Pp3Dmo/stBFcw==
+"@types/node@^14.14.21":
+  version "14.14.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
+  integrity sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2352,6 +2357,31 @@ await-to-js@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/await-to-js/-/await-to-js-2.1.1.tgz#c2093cd5a386f2bb945d79b292817bbc3f41b31b"
   integrity sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==
+
+aws-lambda@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/aws-lambda/-/aws-lambda-1.0.6.tgz#ba562478264646b51e9dc817d7d25ea468ed011b"
+  integrity sha512-Z9lmZBiDYejzjMWuQSDXuZWAqAun6vGt7WApB1r0f8tLNf0IlTGsH30qENfP1kXeTbbMgPpt1bPEeMZjYDTXxQ==
+  dependencies:
+    aws-sdk "*"
+    commander "^3.0.2"
+    js-yaml "^3.13.1"
+    watchpack "^2.0.0-beta.10"
+
+aws-sdk@*:
+  version "2.828.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.828.0.tgz#6aa599c3582f219568f41fb287eb65753e4a9234"
+  integrity sha512-JoDujGdncSIF9ka+XFZjop/7G+fNGucwPwYj7OHYMmFIOV5p7YmqomdbVmH/vIzd988YZz8oLOinWc4jM6vvhg==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sdk@^2.421.0, aws-sdk@^2.624.0:
   version "2.795.0"
@@ -3177,6 +3207,11 @@ commander@^2.20.0, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-3.0.2.tgz#6837c3fb677ad9933d1cfba42dd14d5117d6b39e"
+  integrity sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==
 
 commander@^6.2.0:
   version "6.2.0"
@@ -4905,6 +4940,11 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
+
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@7.1.4:
   version "7.1.4"
@@ -10215,6 +10255,14 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
+
+watchpack@^2.0.0-beta.10:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.1.0.tgz#e63194736bf3aa22026f7b191cd57907b0f9f696"
+  integrity sha512-UjgD1mqjkG99+3lgG36at4wPnUXNvis2v1utwTgQ43C22c4LD71LsYMExdWXh4HZ+RmW+B0t1Vrg2GpXAkTOQw==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## What it does
Implements a lambda for handling deletion of a users attachments. 

## Details
Works by sending a DELETE request against  /users/me/attachments/{filename}. This checks against files belonging to the user making the request, as encoded in the auth-token. 

First checks if such a file exists, and if so, deletes it. Apparently S3s by themselves do not send any type of response in return to deleteObject requests unless version control is turned on, so this check is implemented "by hand", so to speak. This feels a bit weird, but apparently this is how you have to do it.

## To  test
Deploy the lambda through the usual sls deploy, then put a file in the "attachments-s3-{someId}" bucket you should have in your aws environment. Put the file in a folder matching the personal number you are using to test, i.e. for example something like "201111111111/test.jpg". Then, with a valid token with matching personalNumber, try deleting the file. Try also deleting a file that doesn't exist and check the response. 

### Other comments
This lambda is written in TypeScript, but is using the normal serverless-bundle, and coexists peacefully with normal js-services in the same service. So as long you don't use some "weirder" libraries, serverless-bundle works perfectly fine with typescript.