### PR TITLE
feat(collect.js): added support for issuing authorization code

### DIFF
--- a/services/bankid-api/lambdas/collect.js
+++ b/services/bankid-api/lambdas/collect.js
@@ -38,7 +38,7 @@ export const main = async event => {
     );
 
     const [generateAuthorizationCodeError, authorizationCode] = await to(
-      generateAuthorizationCode(bankIdCollectResponse.data.user.personalNumber)
+      generateAuthorizationCode(bankIdCollectResponse.data.completionData.user.personalNumber)
     );
 
     if (generateAuthorizationCodeError) {
@@ -66,7 +66,7 @@ async function generateAuthorizationCode(payload) {
   const [authorizationCodeSecretError, auhtorizationCodeSecret] = await to(
     secrets.get(
       CONFIG_AUTH_SECRETS_AUTHORIZATION_CODE.name,
-      CONFIG_AUTH_SECRETS_AUTHORIZATION_CODE.name
+      CONFIG_AUTH_SECRETS_AUTHORIZATION_CODE.keyName
     )
   );
   if (authorizationCodeSecretError) {
@@ -75,10 +75,10 @@ async function generateAuthorizationCode(payload) {
 
   const tokenExpireTimeInMinutes = 5;
   const [signTokenError, signedToken] = await to(
-    signToken(payload, auhtorizationCodeSecret, tokenExpireTimeInMinutes)
+    signToken({ personalNumber: payload }, auhtorizationCodeSecret, tokenExpireTimeInMinutes)
   );
   if (signTokenError) {
-    throw signTokenError;
+    throwError(401, signTokenError.message);
   }
 
   return signedToken;

--- a/services/bankid-api/lambdas/collect.js
+++ b/services/bankid-api/lambdas/collect.js
@@ -10,7 +10,7 @@ import secrets from '../../../libs/secrets';
 import { signToken } from '../../../libs/token';
 
 const SSMParams = params.read(config.bankId.envsKeyName);
-const authorizationCodeSecretConfig = config.auth.secrets.authorizationCode;
+const CONFIG_AUTH_SECRETS_AUTHORIZATION_CODE = config.auth.secrets.authorizationCode;
 
 export const main = async event => {
   const { orderRef } = JSON.parse(event.body);
@@ -64,7 +64,10 @@ export const main = async event => {
  */
 async function generateAuthorizationCode(payload) {
   const [authorizationCodeSecretError, auhtorizationCodeSecret] = await to(
-    secrets.get(authorizationCodeSecretConfig.name, authorizationCodeSecretConfig.name)
+    secrets.get(
+      CONFIG_AUTH_SECRETS_AUTHORIZATION_CODE.name,
+      CONFIG_AUTH_SECRETS_AUTHORIZATION_CODE.name
+    )
   );
   if (authorizationCodeSecretError) {
     throwError(authorizationCodeSecretError.code, authorizationCodeSecretError.message);

--- a/services/bankid-api/serverless.yml
+++ b/services/bankid-api/serverless.yml
@@ -44,6 +44,10 @@ provider:
       Action:
         - SSM:GetParameter
       Resource: "*"
+    - Effect: Allow
+      Action:
+        - secretsmanager:GetSecretValue
+      Resource: "*"
 
 functions:
   auth:


### PR DESCRIPTION
## Explain the changes you’ve made

Fix the imageUploader component, so that it is in usable shape and adheres to the Figma design. 

## Explain why these changes are made

The auth service have been updated with a new flow for obtaining tokens. In order to obtain a token upon login on the auth service the client needs to obtain an authorization code. Since we do not have a designated endpoint for obtaining a authorization code, this will need to be done when the bankid collect request has the status completed.

## Explain your solution

When the bankID collect request returns the status of complete we generate a jwt token that is signed with a secret (AuthorizationCodeSecret) stored in AWS secrets manager. 

When the token is signed we pass generated it in the bankID collect response on the key authorizationCode.

## How to test the changes?

1. checkout this branch.
2. deploy the bankid service.
3. make sure you have all the secrets configured in AWS secrets (can be found in the config.js)
4. start a bankid authentication process (/bankid/auth).
5. request the bankid collect endpoint (/bankid/collect)
6. when the bankid collect response returns completed, make sure it includes an authorizationCode in the response body attributes.
