### PR TITLE
fix(request-helper): fix a syntax error causing a crash

### DIFF
--- a/services/navet-ms/helpers/client.js
+++ b/services/navet-ms/helpers/client.js
@@ -11,7 +11,7 @@ export const client = async params => {
       passphrase: params.passphrase,
     };
 
-    return requestClient(options, 5000, 'text/xml;charset=UTF-8');
+    return requestClient(options, {}, 5000, 'text/xml;charset=UTF-8');
   } catch (error) {
     return error;
   }


### PR DESCRIPTION
Fixes a syntax error, where we were sending the string 'text/xml;charset=UTF-8' as a timeout value, which was causing a mysterious crash of the navet-ms. 