### PR TITLE
fix(viva-ms): updated status prefix for viva statuses from :ekb to :viva

### DIFF
--- a/libs/caseStatuses.js
+++ b/libs/caseStatuses.js
@@ -29,41 +29,41 @@ const statuses = [
    * Service: Ekonomiskt bistånd
    */
   {
-    type: 'notStarted:ekb',
+    type: 'notStarted:viva',
     name: 'Öppen',
     description: 'Ansökan är öppen. Du kan nu söka ekonomiskt bistånd för perioden.',
   },
   {
-    type: 'active:submitted:ekb',
+    type: 'active:submitted:viva',
     name: 'Inskickad',
     description:
       'Ansökan är inskickad. Du kommer att få besked om ansökan när din handläggare har granskat och bedömt den.',
   },
   {
-    type: 'active:completionRequired:ekb',
+    type: 'active:completionRequired:viva',
     name: 'Stickprovskontroll',
     description:
       'Du måste komplettera din ansökan med bilder som visar dina utgifter och inkomster. Vi behöver din komplettering inom 4 dagar för att kunna betala ut pengar för perioden.',
   },
   {
-    type: 'closed:approved:ekb',
+    type: 'closed:approved:viva',
     name: 'Godkänd',
     description: 'Din ansökan är godkänd. Pengarna sätts in på ditt konto.',
   },
   {
-    type: 'closed:partiallyApproved:ekb',
+    type: 'closed:partiallyApproved:viva',
     name: 'Delvis godkänd',
     description:
       'Delar av din ansökan är godkänd, men några av de utgifter du sökt för får du inte bistånd för. Pengarna för godkända utgifter sätts in på ditt konto.',
   },
   {
-    type: 'closed:rejected:ekb',
+    type: 'closed:rejected:viva',
     name: 'Avslagen',
     description:
       'Din ansökan är inte godkänd och du kommer inte att få någon utbetalning. Vill du överklaga beslutet lämnar du en skriftlig motivering med e-post eller brev till din handläggare.',
   },
   {
-    type: 'closed:completionRejected:ekb',
+    type: 'closed:completionRejected:viva',
     name: 'Avslagen',
     description:
       'Din ansökan är inte godkänd eftersom vi saknar stickprov för perioden. Därför kan vi inte gå vidare och godkänna din ansökan.',

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -95,7 +95,7 @@ async function putRecurringVivaCase(PK, workflowId, period) {
   const ssmParams = await CASE_SSM_PARAMS;
   const id = uuid.v4();
   const timestampNow = Date.now();
-  const initialStatus = getStatusByType('notStarted:ekb');
+  const initialStatus = getStatusByType('notStarted:viva');
 
   const putItemParams = {
     TableName: config.cases.tableName,


### PR DESCRIPTION
## Explain the changes you’ve made
Changed prefix on status types ending with ekb to viva.

## Explain why these changes are made
Since ekb is a acronym and is not used anywhere else in the code base, this can be hard to understand. Viva on the other hand is used as a case provider and is mentioned throughout the code base.

These changes hade it's origin from a conversation with @jonatanhanson. We both agreed that this was a better naming convention for the status types 👍 

## Explain your solution
All status types that ended with :ekb does now end with :viva. Lambdas that relies on setting and getting these statuses have also been updated.
