### PR TITLE
fix(pdf-ms-date-format): add logic for formatting dates in the pdf

### DIFF
--- a/services/pdf-ms/lambdas/addPdfToCase.ts
+++ b/services/pdf-ms/lambdas/addPdfToCase.ts
@@ -60,6 +60,7 @@ export const main = async (event: Record<string, any>) => {
     pdfBaseFileBuffer,
     jsonTemplate,
     caseData.answers,
+    caseData.answersArray,
     changedValues,
     newValues
   );


### PR DESCRIPTION
## What does this do?
Adds logic to the pdf-generator for handling date formatting. Since we've decided to handle all dates in milliseconds (utc), the pdf generator needs to format it to something human readable. 

## Implementation details
Since we have no type information stored in the answers, this relies on tags to identify what answer is a date. So all dates needs to have a 'date' tag for this to work. 

When replacing text from the template, I check if the answer has a 'date' tag. If it does, I use built-in js functionality to format the date to the YYYY-MM-DD format, which is then used for replacing in the template. If it doesn't have a date tag, I just replace with the value. 

## How to test it
Actually tricky, since the current pdf-template for löpande has no dates in it (which it probably should have, but that's a separate issue). So what I did to test it is to add some a new text-node to the template json, like 
```
    {
        "pageIndex": 0,
        "x": 270,
        "y": 548,
        "fontSize": 20,
        "text": "{{testDate}}",
        "valueId": "testDate"
    },
```
and then submit a case with an answer like 
```
 { 
   field: {
     tags: [ 'date' ],
     id: 'testDate'
    },
    value: 1614164400000
}
```
which should show up correctly formatted in the generated pdf. 