### PR TITLE
Feat/check viva completion

### DIFF
--- a/config.js
+++ b/config.js
@@ -31,7 +31,11 @@ const stageConfigs = {
     },
     cases: {
       tableName: 'cases',
-      envsKeyName: '/caseEnvs/dev',
+      providers: {
+        viva: {
+          envsKeyName: '/vivaCaseEnvs/dev',
+        },
+      },
     },
     vada: {
       envsKeyName: '/vadaEnvs/dev',
@@ -71,7 +75,11 @@ const stageConfigs = {
     },
     cases: {
       tableName: 'cases',
-      envsKeyName: '/caseEnvs/test',
+      providers: {
+        viva: {
+          envsKeyName: '/vivaCaseEnvs/test',
+        },
+      },
     },
     vada: {
       envsKeyName: '/vadaEnvs/test',
@@ -111,6 +119,11 @@ const stageConfigs = {
     },
     cases: {
       tableName: 'cases',
+      providers: {
+        viva: {
+          envsKeyName: '/vivaCaseEnvs/stage',
+        },
+      },
     },
     vada: {
       envsKeyName: '/vadaEnvs/stage',
@@ -150,6 +163,11 @@ const stageConfigs = {
     },
     cases: {
       tableName: 'cases',
+      providers: {
+        viva: {
+          envsKeyName: '/vivaCaseEnvs/prod',
+        },
+      },
     },
     vada: {
       envsKeyName: '/vadaEnvs/prod',

--- a/mock/putevents.json
+++ b/mock/putevents.json
@@ -1,11 +1,11 @@
 [
   {
-    "Source": "bankId.collect",
-    "Detail": "{ \"user\": { \"personalNumber\": \"197005012336\" } }",
+    "Source": "vivaMs.submitApplication",
+    "Detail": "{ \"hashedPersonalNumber\": \"Knb6eVz5g8y91dEBzqOA0qwGkAQBRplZ\", \"caseKeys\": { \"PK\": \"USER#196001198685\", \"SK\": \"USER#196001198685#CASE#0d01058f-164e-42ff-96f1-fb7d04b6e5fe\" } }",
     "Resources": [
       "resourceMock1"
     ],
-    "DetailType": "BankIdCollectComplete",
+    "DetailType": "vivaMsSubmitApplicationSuccess",
     "EventBusName": "default"
   }
 ]

--- a/services/viva-ms/helpers/applicationStatus.js
+++ b/services/viva-ms/helpers/applicationStatus.js
@@ -1,0 +1,39 @@
+import * as request from '../../../libs/request';
+import to from 'await-to-js';
+import { throwError } from '@helsingborg-stad/npm-api-error-handling';
+
+export async function getApplicationStatus(hahsedPersonalNumber, ssmParams) {
+  const { vadaUrl, xApiKeyToken } = ssmParams;
+  const authorizedRequestClient = request.requestClient({}, { 'x-api-key': xApiKeyToken });
+
+  const vadaApplicationStatusUrl = `${vadaUrl}/applications/${hahsedPersonalNumber}/status`;
+
+  const [requestError, vadaApplicationStatusResponse] = await to(
+    request.call(authorizedRequestClient, 'get', vadaApplicationStatusUrl)
+  );
+
+  if (requestError) {
+    if (requestError.response) {
+      // The request was made and the server responded with a
+      // status code that falls out of the range of 2xx
+      throwError(requestError.response.status, requestError.response.data.message);
+    } else if (requestError.request) {
+      // The request was made but no response was received
+      // `error.request` is an instance of http.ClientRequest in node.js
+      throwError(500, requestError.request.message);
+    } else {
+      // Something happened in setting up the request that triggered an Error
+      throwError(500, requestError.message);
+    }
+  }
+
+  return vadaApplicationStatusResponse.data;
+}
+
+export function isApplicationStatusCorrect(statusList, requiredStatusCodes) {
+  if (!Array.isArray(statusList)) {
+    return false;
+  }
+  const filteredStatusList = statusList.filter(status => requiredStatusCodes.includes(status.code));
+  return filteredStatusList.length === requiredStatusCodes.length;
+}

--- a/services/viva-ms/lambdas/checkCompletion.js
+++ b/services/viva-ms/lambdas/checkCompletion.js
@@ -55,7 +55,7 @@ async function updateCaseCompletionAttributes(keys, currentFormId) {
   const params = {
     TableName: config.cases.tableName,
     Key: keys,
-    UpdateExpression: 'set currentFormId = :currentFormId, #status=:completionStatus',
+    UpdateExpression: 'set currentFormId = :currentFormId, #status = :completionStatus',
     ExpressionAttributeNames: {
       '#status': 'status',
     },

--- a/services/viva-ms/lambdas/checkCompletion.js
+++ b/services/viva-ms/lambdas/checkCompletion.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+import to from 'await-to-js';
+
+import config from '../../../config';
+import caseStatuses from '../../../libs/caseStatuses';
+import params from '../../../libs/params';
+import * as dynamoDb from '../../../libs/dynamoDb';
+import { getApplicationStatus, isApplicationStatusCorrect } from '../helpers/applicationStatus';
+
+const VADA_SSM_PARAMS = params.read(config.vada.envsKeyName);
+const CASE_SSM_PARAMS = params.read(config.cases.envsKeyName);
+
+export async function main(event) {
+  const { hashedPersonalNumber, caseKeys } = event.detail;
+
+  const vadaSSMParams = await VADA_SSM_PARAMS;
+  const [applicationStatusRequestError, applicationStatusList] = await to(
+    getApplicationStatus(hashedPersonalNumber, vadaSSMParams)
+  );
+  if (applicationStatusRequestError) {
+    throw applicationStatusRequestError;
+  }
+
+  /**
+   * The Combination of Status Codes 64, 128, 256, 512
+   * determines if a VIVA Application Workflow requires completion
+   * 64 - Completion is required,
+   * 128 - Case exsits in VIVA
+   * 256 - An active e-application is activated in VIVA
+   * 512 - Application allows e-application
+   */
+  const completionStatusCodes = [64, 128, 256, 512];
+  if (!isApplicationStatusCorrect(applicationStatusList, completionStatusCodes)) {
+    throw 'no completion status found in viva adapter response';
+  }
+
+  const caseSSMParams = await CASE_SSM_PARAMS;
+  const [updateCaseError, caseItem] = await to(
+    updateCaseCompletionAttributes(caseKeys, caseSSMParams.recurringFormId)
+  );
+  if (updateCaseError) {
+    throw updateCaseError;
+  }
+
+  console.log(caseItem);
+}
+
+async function updateCaseCompletionAttributes(keys, formId) {
+  // TODO: use utility function for getting status
+  const completionStatus = caseStatuses.find(
+    status => status.type === 'active:completionRequired:viva'
+  );
+  const params = {
+    TableName: config.cases.tableName,
+    Key: keys,
+    UpdateExpression: 'set currentFormId = :formId, #status=:completionStatus',
+    ExpressionAttributeNames: {
+      '#status': 'status',
+    },
+    ExpressionAttributeValues: {
+      ':formId': formId,
+      ':completionStatus': completionStatus,
+    },
+    ReturnValues: 'UPDATED_NEW',
+  };
+
+  const [updateCaseError, caseItem] = await to(dynamoDb.call('update', params));
+  if (updateCaseError) {
+    throw updateCaseError;
+  }
+
+  return caseItem;
+}

--- a/services/viva-ms/lambdas/checkCompletion.js
+++ b/services/viva-ms/lambdas/checkCompletion.js
@@ -8,7 +8,7 @@ import { getApplicationStatus, isApplicationStatusCorrect } from '../helpers/app
 import { getStatusByType } from '../../../libs/caseStatuses';
 
 const VADA_SSM_PARAMS = params.read(config.vada.envsKeyName);
-const CASE_SSM_PARAMS = params.read(config.cases.envsKeyName);
+const VIVA_CASE_SSM_PARAMS = params.read(config.cases.providers.viva.envsKeyName);
 
 export async function main(event) {
   const { hashedPersonalNumber, caseKeys } = event.detail;
@@ -34,9 +34,9 @@ export async function main(event) {
     throw 'no completion status found in viva adapter response';
   }
 
-  const caseSSMParams = await CASE_SSM_PARAMS;
+  const vivaCaseSSMParams = await VIVA_CASE_SSM_PARAMS;
   const [updateCaseError, caseItem] = await to(
-    updateCaseCompletionAttributes(caseKeys, caseSSMParams.recurringFormId)
+    updateCaseCompletionAttributes(caseKeys, vivaCaseSSMParams.completionFormId)
   );
   if (updateCaseError) {
     throw updateCaseError;

--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -44,8 +44,8 @@ export async function main(event) {
         personalNumberHashEncoded,
         caseKeys,
       },
-      'vivamsSubmitApplicationSuccess',
-      'vivams.submitApplication'
+      'vivaMsSubmitApplicationSuccess',
+      'vivaMs.submitApplication'
     )
   );
   if (putEventError) {

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -32,6 +32,10 @@ provider:
       Resource: "*"
     - Effect: Allow
       Action:
+        - events:PutEvents
+      Resource: "*"
+    - Effect: Allow
+      Action:
         - dynamodb:UpdateItem
         - dynamodb:PutItem
         - dynamodb:Query
@@ -98,3 +102,11 @@ functions:
               - bankId.collect
             detail-type:
               - BankIdCollectComplete
+
+  checkCompletion:
+    handler: lambdas/checkCompletion.main
+    events:
+      - eventBridge:
+          pattern:
+            source:
+              - vivams.submitApplication

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -109,4 +109,4 @@ functions:
       - eventBridge:
           pattern:
             source:
-              - vivams.submitApplication
+              - vivaMs.submitApplication


### PR DESCRIPTION
## Explain the changes you’ve made
Added support for updating a case with correct data when the application status in viva is set to require completion (Stickprov).

## Explain why these changes are made
These changes handels updating of a submitted case when viva needs an applicant to pass additional completion information.

## Explain your solution
This includes handling events for when a viva application is successfully submitted, checking if the application status is set to require completion and updating the case with information in order to start a completion process.

## How to test the changes?

**Setup environment**
1. Checkout this branch.
2. Deploy the viva-ms service.
3. Add a new test user with the personal number 196001198685 (Vera Toth)
4. Add a new case for this user.
5. Open up CloudWatch for the checkCompletion Lambda in the AWS console

**Setup event to send**
1. Go to the EventBridge in AWS and prepare to send a new event (EventBridge -> eventbuses -> default -> send event) 
2. Add the following input in the send event view:
Event Source: vivaMs.submitApplication
Detail Type: vivaMsSubmitApplicationSuccess
Event detail: {
	"hashedPersonalNumber": "a_hashed_personal_numer",
	"caseKeys": {
		"PK": "pk_for_case",
		"SK": "sk_for_case"
	}
}

**Scenario One**
Send an event on any user that does not have any completion to fullfill (Anyone except Vera Toth).

Result: The case should not update currentFormId or the status

**Scenarion Two**
Send an event on Vera Toth that should have an ongoing completion.

Result: The case should update the currentFormId and the status on the case.


## Anyhting else? (optional)
If you rather have a review in person or have problem with setting up the test environment, just send me a message.
