### PR TITLE
fix: 🐛 (viva-ms) variable completionFormId

### DIFF
--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -114,7 +114,7 @@ async function queryCasesWithWorkflowId(PK, workflowId) {
 
 async function putRecurringVivaCase(PK, workflowId, period) {
   const ssmParams = await VIVA_CASE_SSM_PARAMS;
-  const { recurringFormId, randomCheckFormId } = ssmParams;
+  const { recurringFormId, completionFormId } = ssmParams;
   const id = uuid.v4();
   const timestampNow = Date.now();
   const initialStatus = getStatusByType('notStarted:viva');
@@ -131,7 +131,7 @@ async function putRecurringVivaCase(PK, workflowId, period) {
 
   const initialForms = {
     [recurringFormId]: initialFormAttributes,
-    [randomCheckFormId]: initialFormAttributes,
+    [completionFormId]: initialFormAttributes,
   };
 
   const putItemParams = {


### PR DESCRIPTION
Vad?
Fel referens till vad som är angivet i ssm-params. Rätt attribut är completionFormId. I kodbasen var randomCheckFormId angivet.

Hur?
Bytt namn på variabeln till completionFormId för att matcha attributet för ssm-params - /vivaCaseEnvs/dev

Har testat
Egen sandbox - Ok

Hur testar jag?
Se till att ssm-parametern /vivaCaseEnvs/dev finns i din sandbox -> AWS / System Manager / Parameter Store
`{
  "recurringFormId": "f9a4f990-32da-11eb-b128-cb042fcdd306",
  "completionFormId": "73c7b800-4e9e-11eb-b918-05b2880122e5"
}`
FormId'n skiljer sig säkert från dessa. Ange Dina formId'n som du har i Din DynamoDB froms tabell för respektive formulär.

Klona branche'n
kör `sls deploy` i mappen viva-ms
Logga in via appen med Harald Unge 197005012336 (Måste finns i Din DynamoDB users tabell)
Verifiera att ett ärende skapas och forms innehåller två objekt med formId för resp. formulär - stickprov/löpande

Exempel på förväntat resultat på nyskapat case
`{
  "createdAt": 1615245819502,
  "currentFormId": "f9a4f990-32da-11eb-b128-cb042fcdd306",
  "details": {
    "administrators": [
      {
        "email": "oscar.lundstrom@helsingborg.se",
        "name": "Oscar Lundström",
        "phone": "042102237",
        "title": "Socialsekreterare"
      }
    ],
    "period": {
      "endDate": 1619740800000,
      "startDate": 1617235200000
    },
    "workflowId": "AF6F908B0498F350C125868E006F4FF2"
  },
  "forms": {
    "73c7b800-4e9e-11eb-b918-05b2880122e5": {
      "answers": [],
      "currentPosition": {
        "currentMainStep": 1,
        "currentMainStepIndex": 0,
        "index": 0,
        "level": 0
      }
    },
    "f9a4f990-32da-11eb-b128-cb042fcdd306": {
      "answers": [],
      "currentPosition": {
        "currentMainStep": 1,
        "currentMainStepIndex": 0,
        "index": 0,
        "level": 0
      }
    }
  },
  "id": "e2708777-3dc4-4c1b-b7a6-4a2a00955594",
  "PK": "USER#197005012336",
  "provider": "VIVA",
  "SK": "USER#197005012336#CASE#e2708777-3dc4-4c1b-b7a6-4a2a00955594",
  "status": {
    "description": "Ansökan är öppen. Du kan nu söka ekonomiskt bistånd för perioden.",
    "name": "Öppen",
    "type": "notStarted:viva"
  },
  "updatedAt": 1615245819502
}`
