### PR TITLE
Feat/submit completion

### DIFF
--- a/services/viva-ms/lambdas/submitCompletion.js
+++ b/services/viva-ms/lambdas/submitCompletion.js
@@ -1,0 +1,189 @@
+/* eslint-disable no-console */
+import AWS from 'aws-sdk';
+import S3 from '../../../libs/S3';
+import { to } from 'await-to-js';
+import params from '../../../libs/params';
+import config from '../../../config';
+import * as request from '../../../libs/request';
+import { throwError } from '@helsingborg-stad/npm-api-error-handling';
+import hash from '../../../libs/helperHashEncode';
+
+const VIVA_CASE_SSM_PARAMS = params.read(config.cases.providers.viva.envsKeyName);
+const VADA_SSM_PARAMS = params.read(config.vada.envsKeyName);
+
+export async function main(event) {
+  const vivaCaseSsmParams = await VIVA_CASE_SSM_PARAMS;
+  const caseItem = parseDynamoDBItemFromEvent(event);
+
+  if (caseItem.currentFormId !== vivaCaseSsmParams.completionFormId) {
+    console.info('(viva-ms: submitApplication): currentFormId does not match completionFormId');
+    return false;
+  }
+
+  const personalNumber = caseItem.PK.substr(5);
+
+  const caseAnswers = caseItem.forms[caseItem.currentFormId].answers;
+
+  const [attachmentListError, attachmentList] = await to(
+    answersToAttachmentList(personalNumber, caseAnswers)
+  );
+  if (attachmentListError) {
+    throw attachmentListError;
+  }
+
+  // send attachments to viva.
+  const { vadaUrl, xApiKeyToken, hashSalt, hashSaltLength } = await VADA_SSM_PARAMS;
+
+  const hashedPersonalNumber = hash.encode(personalNumber, hashSalt, hashSaltLength);
+  const requestParams = {
+    url: `${vadaUrl}/applications/${hashedPersonalNumber}/completions`,
+    method: 'post',
+    headers: {
+      'x-api-key': xApiKeyToken,
+    },
+    body: {
+      workflowId: caseItem.details.workflowId,
+      attachments: attachmentList,
+    },
+  };
+
+  const [sendVivaAdapterRequestError, response] = await to(sendVivaAdapterRequest(requestParams));
+  if (sendVivaAdapterRequestError) {
+    throw sendVivaAdapterRequestError;
+  }
+  console.info(response);
+
+  return true;
+}
+
+function parseDynamoDBItemFromEvent(event) {
+  if (event.detail.dynamodb.NewImage === undefined) {
+    throw 'Could not read dynamoDB image from event details';
+  }
+  const dynamoDBItem = AWS.DynamoDB.Converter.unmarshall(event.detail.dynamodb.NewImage);
+  return dynamoDBItem;
+}
+
+// const answers = [
+//   {
+//     field: {
+//       id: '1',
+//       tags: ['viva', 'attachment', 'category', 'expenses'],
+//     },
+//     value: [
+//       {
+//         fileame: 'test.jpg',
+//         uploadedFileName: '182c4d16-de4c-44df-9df5-3dbc98030280_somefile',
+//       },
+//       {
+//         fileame: 'test.jpg',
+//         uploadedFileName: 'does_not_exsits',
+//       },
+//     ],
+//   },
+//   {
+//     field: {
+//       id: '2',
+//       tags: ['viva', 'attachment', 'category', 'incomes'],
+//     },
+//     value: [
+//       {
+//         fileame: 'test.jpg',
+//         uploadedFileName: '182c4d16-de4c-44df-9df5-3dbc98030280_somefile',
+//       },
+//       {
+//         fileame: 'test.jpg',
+//         uploadedFileName: 'does_not_exsits',
+//       },
+//     ],
+//   },
+//   {
+//     field: {
+//       id: '3',
+//       tags: ['viva', 'attachment', 'category', 'completion'],
+//     },
+//     value: [
+//       {
+//         fileame: 'test.jpg',
+//         uploadedFileName: '182c4d16-de4c-44df-9df5-3dbc98030280_somefile',
+//       },
+//       {
+//         fileame: 'test.jpg',
+//         uploadedFileName: 'does_not_exsits',
+//       },
+//     ],
+//   },
+// ];
+
+function getAttachmentCategory(tags, attachmentCategories = ['expenses', 'incomes', 'completion']) {
+  if (tags && tags.includes('viva') && tags.includes('attachment') && tags.includes('category')) {
+    return attachmentCategories.reduce((acc, curr) => {
+      if (tags.includes(curr)) {
+        return curr;
+      }
+      return acc;
+    }, undefined);
+  }
+  return undefined;
+}
+
+function generateFileKey(keyPrefix, filename) {
+  return `${keyPrefix}/${filename}`;
+}
+
+async function answersToAttachmentList(personalNumber, answerList) {
+  const attachmentList = [];
+
+  for (const answer of answerList) {
+    const attachmentCategory = getAttachmentCategory(answer.field.tags);
+    if (!attachmentCategory) {
+      continue;
+    }
+
+    for (const valueItem of answer.value) {
+      const s3FileKey = generateFileKey(personalNumber, valueItem.uploadedFileName);
+
+      // TODO: import bucketname from env
+      const [getFileError, file] = await to(S3.getFile(process.env.BUCKET_NAME, s3FileKey));
+      if (getFileError) {
+        console.info(s3FileKey, getFileError);
+        continue;
+      }
+
+      const attachment = {
+        id: s3FileKey,
+        name: valueItem.filename,
+        category: attachmentCategory,
+        fileBase64: file.Body.toString('base64'),
+      };
+
+      attachmentList.push(attachment);
+    }
+  }
+
+  return attachmentList;
+}
+
+async function sendVivaAdapterRequest(requestParams) {
+  const { url, method, headers, body } = await requestParams;
+  const requestClient = request.requestClient({}, headers);
+
+  const [requestError, response] = await to(request.call(requestClient, method, url, body));
+
+  if (requestError) {
+    if (requestError.response) {
+      // The request was made and the server responded with a
+      // status code that falls out of the range of 2xx
+      throwError(requestError.response.status, requestError.response.data.message);
+    } else if (requestError.request) {
+      // The request was made but no response was received
+      // `error.request` is an instance of http.ClientRequest in node.js
+      throwError(500, requestError.request.message);
+    } else {
+      // Something happened in setting up the request that triggered an Error
+      throwError(500, requestError.message);
+    }
+  }
+
+  return response.data;
+}

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -114,12 +114,18 @@ functions:
 
   checkCompletion:
     handler: lambdas/checkCompletion.main
-    events:
-      - eventBridge:
-          pattern:
-            source:
-              - vivaMs.submitApplication
-
+              - MODIFY
+            detail:
+              dynamodb:
+                NewImage:
+                  status:
+                    M:
+                      type:
+                        S:
+                          [
+                            { "prefix": "active:submitted" },
+                            { "prefix": "active:ongoing" },
+                          ]
   submitCompletion:
     handler: lambdas/submitCompletion.main
     environment:

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -143,4 +143,4 @@ functions:
                   status:
                     M:
                       type:
-                        S: [{ "prefix": "active:completionSubmitted:viva" }]
+                        S: [{ "prefix": "active:submitted:viva" }]

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -123,18 +123,12 @@ functions:
 
   checkCompletion:
     handler: lambdas/checkCompletion.main
-              - MODIFY
-            detail:
-              dynamodb:
-                NewImage:
-                  status:
-                    M:
-                      type:
-                        S:
-                          [
-                            { "prefix": "active:submitted" },
-                            { "prefix": "active:ongoing" },
-                          ]
+    events:
+      - eventBridge:
+          pattern:
+            source:
+              - vivaMs.submitApplication
+
   submitCompletion:
     handler: lambdas/submitCompletion.main
     environment:

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -32,6 +32,10 @@ provider:
       Resource: "*"
     - Effect: Allow
       Action:
+        - events:PutEvents
+      Resource: "*"
+    - Effect: Allow
+      Action:
         - s3:GetObject
       Resource:
         - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -32,8 +32,13 @@ provider:
       Resource: "*"
     - Effect: Allow
       Action:
-        - events:PutEvents
-      Resource: "*"
+        - s3:GetObject
+      Resource:
+        - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
+        - Fn::Join:
+            - ""
+            - - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
+              - "/*"
     - Effect: Allow
       Action:
         - s3:GetObject

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -105,8 +105,33 @@ functions:
 
   checkCompletion:
     handler: lambdas/checkCompletion.main
+              - MODIFY
+            detail:
+              dynamodb:
+                NewImage:
+                  status:
+                    M:
+                      type:
+                        S:
+                          [
+                            { "prefix": "active:submitted" },
+                            { "prefix": "active:ongoing" },
+                          ]
+  submitCompletion:
+    handler: lambdas/submitCompletion.main
+    environment:
+      BUCKET_NAME: !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
     events:
       - eventBridge:
           pattern:
             source:
-              - vivaMs.submitApplication
+              - cases.database
+            detail-type:
+              - MODIFY
+            detail:
+              dynamodb:
+                NewImage:
+                  status:
+                    M:
+                      type:
+                        S: [{ "prefix": "active:completionSubmitted:viva" }]

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -114,18 +114,12 @@ functions:
 
   checkCompletion:
     handler: lambdas/checkCompletion.main
-              - MODIFY
-            detail:
-              dynamodb:
-                NewImage:
-                  status:
-                    M:
-                      type:
-                        S:
-                          [
-                            { "prefix": "active:submitted" },
-                            { "prefix": "active:ongoing" },
-                          ]
+    events:
+      - eventBridge:
+          pattern:
+            source:
+              - vivaMs.submitApplication
+
   submitCompletion:
     handler: lambdas/submitCompletion.main
     environment:

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -32,8 +32,13 @@ provider:
       Resource: "*"
     - Effect: Allow
       Action:
-        - events:PutEvents
-      Resource: "*"
+        - s3:GetObject
+      Resource:
+        - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
+        - Fn::Join:
+            - ""
+            - - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
+              - "/*"
     - Effect: Allow
       Action:
         - dynamodb:UpdateItem


### PR DESCRIPTION
## Explain the changes you’ve made
Added support for posting case answers to the viva adapter for a completion form.

## Explain why these changes are made
So that we can send a completion data from a case to viva through the viva adpater.

## Explain your solution
The main logic for this new lambda is to convert case form answers to the data format that our viva adapter expects and post that data to it's completions endpoint (vadaurl/applications/hash_id/completions).

When we convert the answers we do a couple of things:
1. Match tags (answer.field.tags) on a answer to allowed attachment categories ('expenses', 'incomes', 'completion'), if the tagging is wrong the values (filedata) in the answer will not be processed.
2. Retrieve the corresponding file from s3 based on data present in an answer value.
3. Create the attachment object with file binary data (base64), file category etc.

If the creation of the attachment array from answers is successful we make a post request to the viva adapter, the adapter then communicate with viva and append the files/attachment to the workflow


## How to test the changes?

**OBS!**
For this to work with viva, the user being used must be a user that is allowed to submit a completion on a case in viva.
@dannil76 can help you with the user setup. 

**Services:**
Deploy the _viva-ms_ service to your AWS sandbox.
Make sure your _user-api_ service is deployed. (We need the attachment endpoint to upload images/files)

**SSM Params:**
_vadaEnvs_ and _vivaCaseEnvs_ need to be present.

**S3:**
Make sure the user attachment bucket from the resource repo is deployed.

TEST WITH APP:
Go through a completion form and submit it (stickprov).

TEST IN AWS:
1. Upload images to the user attachment bucket through the endpoint users/me/attachments
2. Create a new case in DynamoDB with the test data provided further down, make sure to replace placeholder values.
3. Update the status type in the case to active:submitted:viva
4. Confirm that the lambda has run without errors in CloudWatch (search for: submitCompletion)


TEST DATA FOR DYNAMODB:
```
{
  "createdAt": 1612515760317,
  "currentFormId": "YOUR_COMPLETION_FORM_ID",
  "details": {
    "administrators": [ ],
    "period": {
      "end": 1614470400000,
      "start": 1612137600000
    },
    "workflowId": "REPLACE_WITH_WORKFLOW_ID_FOR_ACTIVE_WORKFLOW_IN_VIVA"
  },
  "forms": {
    "YOUR_RECURRING_FORM_ID": {
      "answers": [ ], 
      "currentPosition": {
        "currentMainStep": 1,
        "currentMainStepIndex": 0,
        "index": 0,
        "level": 0
      }
    },
    "YOUR_COMPLETION_FORM_ID": {
      "answers": [
        // Feel free to add more fields
        {
          "field": {
            "id": "addRent",
            "tags": [
              "attachment",
              "viva",
              "category",
              "incomes" // this tag value can be one of the following: incomes, expenses or completion
            ]
          },
          "value": [
            {
              // test data for none existing files
              "filename": "does_not_exist.jpg",
              "uploadedFileName": "not_uploaded_file"
            },
            {
              "filename": "test_1.jpg",
              "uploadedFileName": REPLACE_WITH_S3_GENERATED_FILE_NAME
            }
          ]
        },
       {
          "field": {
            "id": "skipThisAnswer",
            "tags": [
              "not_a_valid_tag",
              "skip_this_answer"
            ]
          },
          "value": [
            {
              "filename": "test_1.jpg",
              "uploadedFileName": REPLACE_WITH_S3_GENERATED_FILE_NAME
            }
          ]
        }
      ],
      "currentPosition": {
        "currentMainStep": 1,
        "currentMainStepIndex": 0,
        "index": 0,
        "level": 0
      }
    }
  },
  "id": "9a939342-acc5-4357-bea4-4b4708991234",
  "PK": "USER#REPLACE_WITH_USER_PERSONALNUMBER",
  "provider": "VIVA",
  "SK": "USER#REPLACE_WITH_USER_PERSONALNUMBER#CASE#9a939342-acc5-4357-bea4-4b4708991234",
  "status": {
    "description": "Du måste komplettera din ansökan med bilder som visar dina utgifter och inkomster. Vi behöver din komplettering inom 4 dagar för att kunna betala ut pengar för perioden.",
    "name": "Stickprovskontroll",
    "type": "active:completionRequired:viva"
  },
  "updatedAt": 1612515760317
}
```


## Was this feature tested in the following environments?
- [X] AWS personal sandbox env.

## Additional thoughts
When retrieving files from a S3 bucket, S3 requires a fileKey. This fileKey should preferable be saved on values in form answers, now we only save the filename of the uploaded file (uploadedFIleName). This requires the lambda to create the fileKey in order to retrieve the file from S3. 
I do not know what s3 returns to the app when a file is uploaded, but if the fileKey is returned we should pass it to avoid stitching it back together in the lambda.
