### PR TITLE
Sync workflow status rejected, approved, partiallyApproved and completionRequired

### DIFF
--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -105,17 +105,28 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
   let UpdateExpression = `SET ${CASE_WORKFLOW_PATH} = :newWorkflow`;
   const ExpressionAttributeValues = { ':newWorkflow': workflow };
   const ExpressionAttributeNames = {};
+  let decisionStatus = 0;
 
-  const typeCode = workflow.decision?.decisions?.decision?.type?.typecode;
+  const decisionList = workflow.decision?.decisions?.decision;
+  if (decisionList === undefined) {
+    // TODO: Return error.
+  }
 
-  if (typeCode === '01') {
+  decisionList.forEach(decision => {
+    const decisionType = decision.typecode;
+    decisionStatus = decisionStatus | parseInt(decisionType, 10);
+  });
+
+  if (decisionStatus === 0) {
+    // TODO: Check if stickprov.
+  }
+
+  if (decisionStatus === 1) {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
-  } else if (typeCode === '02') {
+  } else if (decisionStatus === 2) {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
-  } else if (typeCode === '03') {
+  } else if (decisionStatus === 3) {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
-  } else if (workflow.calculations) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('active:processing');
   }
 
   if (ExpressionAttributeValues[':newStatus']) {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -18,6 +18,9 @@ export async function main(event) {
     return console.error('(Viva-ms) DynamoDB query failed', getAllUserCasesError);
   }
 
+  const workflowIds = getWorkflowIds(allUserCases);
+  await syncCaseWorkflowsRew(workflowIds, personalNumber);
+
   await syncCaseWorkflows(allUserCases, personalNumber);
 
   return true;
@@ -36,6 +39,25 @@ async function getAllUserCases(PK) {
 
   return dynamoDb.call('query', params);
 }
+
+function getWorkflowIds(cases) {
+  const workflowIds = [];
+  const caseItems = cases.Items;
+
+  for (const caseItem of caseItems) {
+    const workflowId = caseItem.details.workflowId;
+    if (!workflowId) {
+      continue;
+    }
+
+    workflowIds.push(workflowId);
+  }
+
+  return workflowIds;
+}
+
+// eslint-disable-next-line no-unused-vars
+async function syncCaseWorkflowsRew(workflows, personalNumber) {}
 
 async function syncCaseWorkflows(cases, personalNumber) {
   const caseItems = cases.Items;

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -80,11 +80,7 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
   let decisionStatus = 0;
 
   const decisionList = workflow.decision?.decisions?.decision;
-  if (decisionList === undefined) {
-    if (workflow?.application?.requestingcompletion === '1') {
-      ExpressionAttributeValues[':newStatus'] = getStatusByType('active:completionRequired:viva');
-    }
-  } else {
+  if (decisionList !== undefined) {
     decisionList.forEach(decision => {
       const decisionType = decision.typecode;
       decisionStatus = decisionStatus | parseInt(decisionType, 10);

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -110,24 +110,22 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
 
   const decisionList = workflow.decision?.decisions?.decision;
   if (decisionList === undefined) {
-    // TODO: Return error.
-  }
+    if (workflow?.application?.requestingcompletion === '1') {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('active:completionRequired:viva');
+    }
+  } else {
+    decisionList.forEach(decision => {
+      const decisionType = decision.typecode;
+      decisionStatus = decisionStatus | parseInt(decisionType, 10);
+    });
 
-  decisionList.forEach(decision => {
-    const decisionType = decision.typecode;
-    decisionStatus = decisionStatus | parseInt(decisionType, 10);
-  });
-
-  if (decisionStatus === 0) {
-    // TODO: Check if stickprov.
-  }
-
-  if (decisionStatus === 1) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
-  } else if (decisionStatus === 2) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
-  } else if (decisionStatus === 3) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
+    if (decisionStatus === 1) {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
+    } else if (decisionStatus === 2) {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
+    } else if (decisionStatus === 3) {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
+    }
   }
 
   if (ExpressionAttributeValues[':newStatus']) {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -109,24 +109,22 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
 
   const decisionList = workflow.decision?.decisions?.decision;
   if (decisionList === undefined) {
-    // TODO: Return error.
-  }
+    if (workflow?.application?.requestingcompletion === '1') {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('active:completionRequired:viva');
+    }
+  } else {
+    decisionList.forEach(decision => {
+      const decisionType = decision.typecode;
+      decisionStatus = decisionStatus | parseInt(decisionType, 10);
+    });
 
-  decisionList.forEach(decision => {
-    const decisionType = decision.typecode;
-    decisionStatus = decisionStatus | parseInt(decisionType, 10);
-  });
-
-  if (decisionStatus === 0) {
-    // TODO: Check if stickprov.
-  }
-
-  if (decisionStatus === 1) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
-  } else if (decisionStatus === 2) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
-  } else if (decisionStatus === 3) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
+    if (decisionStatus === 1) {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
+    } else if (decisionStatus === 2) {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
+    } else if (decisionStatus === 3) {
+      ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
+    }
   }
 
   if (ExpressionAttributeValues[':newStatus']) {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -106,17 +106,28 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
   let UpdateExpression = `SET ${CASE_WORKFLOW_PATH} = :newWorkflow`;
   const ExpressionAttributeValues = { ':newWorkflow': workflow };
   const ExpressionAttributeNames = {};
+  let decisionStatus = 0;
 
-  const typeCode = workflow.decision?.decisions?.decision?.type?.typecode;
+  const decisionList = workflow.decision?.decisions?.decision;
+  if (decisionList === undefined) {
+    // TODO: Return error.
+  }
 
-  if (typeCode === '01') {
+  decisionList.forEach(decision => {
+    const decisionType = decision.typecode;
+    decisionStatus = decisionStatus | parseInt(decisionType, 10);
+  });
+
+  if (decisionStatus === 0) {
+    // TODO: Check if stickprov.
+  }
+
+  if (decisionStatus === 1) {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
-  } else if (typeCode === '02') {
+  } else if (decisionStatus === 2) {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
-  } else if (typeCode === '03') {
+  } else if (decisionStatus === 3) {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
-  } else if (workflow.calculations) {
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('active:processing');
   }
 
   if (ExpressionAttributeValues[':newStatus']) {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -107,14 +107,21 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
   const ExpressionAttributeValues = { ':newWorkflow': workflow };
   const ExpressionAttributeNames = {};
 
-  if (workflow.decision?.decisions?.decision?.type?.typecode === '01') {
-    UpdateExpression += ', #status = :newStatus';
-    ExpressionAttributeNames['#status'] = 'status';
+  const typeCode = workflow.decision?.decisions?.decision?.type?.typecode;
+
+  if (typeCode === '01') {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
+  } else if (typeCode === '02') {
+    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
+  } else if (typeCode === '03') {
+    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
   } else if (workflow.calculations) {
+    ExpressionAttributeValues[':newStatus'] = getStatusByType('active:processing');
+  }
+
+  if (ExpressionAttributeValues[':newStatus']) {
     UpdateExpression += ', #status = :newStatus';
     ExpressionAttributeNames['#status'] = 'status';
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('active:processing');
   }
 
   const params = {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -106,7 +106,7 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
   const ExpressionAttributeValues = { ':newWorkflow': workflow };
   const ExpressionAttributeNames = {};
 
-  if (workflow.decision?.decisions?.decision?.type === 'Beviljat') {
+  if (workflow.decision?.decisions?.decision?.type?.typecode === '01') {
     UpdateExpression += ', #status = :newStatus';
     ExpressionAttributeNames['#status'] = 'status';
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -106,14 +106,21 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
   const ExpressionAttributeValues = { ':newWorkflow': workflow };
   const ExpressionAttributeNames = {};
 
-  if (workflow.decision?.decisions?.decision?.type?.typecode === '01') {
-    UpdateExpression += ', #status = :newStatus';
-    ExpressionAttributeNames['#status'] = 'status';
+  const typeCode = workflow.decision?.decisions?.decision?.type?.typecode;
+
+  if (typeCode === '01') {
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');
+  } else if (typeCode === '02') {
+    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:rejected:viva');
+  } else if (typeCode === '03') {
+    ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:partiallyApproved:viva');
   } else if (workflow.calculations) {
+    ExpressionAttributeValues[':newStatus'] = getStatusByType('active:processing');
+  }
+
+  if (ExpressionAttributeValues[':newStatus']) {
     UpdateExpression += ', #status = :newStatus';
     ExpressionAttributeNames['#status'] = 'status';
-    ExpressionAttributeValues[':newStatus'] = getStatusByType('active:processing');
   }
 
   const params = {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -13,7 +13,10 @@ export async function main(event) {
   const personalNumber = event.detail.user.personalNumber;
   const PK = `USER#${personalNumber}`;
 
-  const allUserCases = await getAllUserCases(PK);
+  const [getAllUserCasesError, allUserCases] = await to(getAllUserCases(PK));
+  if (getAllUserCasesError) {
+    return console.error('(Viva-ms) DynamoDB query failed', getAllUserCasesError);
+  }
 
   await syncCaseWorkflows(allUserCases, personalNumber);
 
@@ -31,12 +34,7 @@ async function getAllUserCases(PK) {
     },
   };
 
-  const [error, casesGetResponse] = await to(dynamoDb.call('query', params));
-  if (error) {
-    return console.error('(Viva-ms) syncWorkflow', error);
-  }
-
-  return casesGetResponse;
+  return dynamoDb.call('query', params);
 }
 
 async function syncCaseWorkflows(cases, personalNumber) {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -30,7 +30,8 @@ export async function main(event) {
       vivaAdapter.workflow.get({ personalNumber, workflowId })
     );
     if (myPagesError) {
-      return console.error('(Viva-ms) My pages request error', myPagesError);
+      console.error('(Viva-ms) My pages request error', myPagesError);
+      continue;
     }
 
     if (!deepEqual(myPagesResponse.attributes, userCase.details?.workflow)) {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -27,7 +27,7 @@ export async function main(event) {
     const workflowId = userCase.details.workflowId;
 
     const [myPagesError, myPagesResponse] = await to(
-      sendVadaMyPagesRequest(personalNumber, workflowId)
+      vivaAdapter.workflow.get({ personalNumber, workflowId })
     );
     if (myPagesError) {
       return console.error('(Viva-ms) My pages request error', myPagesError);
@@ -69,35 +69,6 @@ function getWorkflowIds(cases) {
   }
 
   return workflowIds;
-}
-
-// eslint-disable-next-line no-unused-vars
-async function syncCaseWorkflowsRew(workflows, personalNumber) {}
-
-async function syncCaseWorkflows(cases, personalNumber) {
-  const caseItems = cases.Items;
-
-  for (const caseItem of caseItems) {
-    const workflowId = caseItem.details.workflowId;
-
-    if (!workflowId) {
-      continue;
-    }
-
-    const [getWorkflowError, workflow] = await to(
-      vivaAdapter.workflow.get({
-        personalNumber,
-        workflowId,
-      })
-    );
-    if (getWorkflowError) {
-      return console.error('(Viva-ms) syncWorkflow', getWorkflowError);
-    }
-
-    if (!deepEqual(workflow.attributes, caseItem.details.workflow)) {
-      await syncWorkflowAndStatus(caseItem.PK, caseItem.SK, workflow.attributes);
-    }
-  }
 }
 
 async function syncWorkflowAndStatus(PK, SK, workflow) {

--- a/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
+++ b/services/viva-ms/lambdas/syncWorkflowAndSetStatus.js
@@ -107,7 +107,7 @@ async function syncWorkflowAndStatus(PK, SK, workflow) {
   const ExpressionAttributeValues = { ':newWorkflow': workflow };
   const ExpressionAttributeNames = {};
 
-  if (workflow.decision?.decisions?.decision?.type === 'Beviljat') {
+  if (workflow.decision?.decisions?.decision?.type?.typecode === '01') {
     UpdateExpression += ', #status = :newStatus';
     ExpressionAttributeNames['#status'] = 'status';
     ExpressionAttributeValues[':newStatus'] = getStatusByType('closed:approved:viva');


### PR DESCRIPTION
## Explain the changes you’ve made
Updating case with VIVA statuses rejected, approved,  partiallyApproved and completionRequired.

## Explain your solution
For rejected, approved and  partiallyApproved we check decisionStatus in workflow before setting status for case accordingly.
If several decisions are made, for the same case, we set status partially approved if we find both rejected and approved decisions.

## How to test the changes?
### Test partially approved
**Setup case in AWS:**
```
{
  "answers": [

  ],
  "createdAt": 1611758051108,
  "currentPosition": 3,
  "details": {
    "period": {
      "end": "2021-02-28",
      "start": "2021-02-01"
    },
    "workflowId": "52B708385081D282C125869B0048416D"
  },
  "expirationTime": 1,
  "formId": "0",
  "id": "ac48eedf-819f-4011-bbe8-da6cc2c8c5b4",
  "pdfGenerated": true,
  "PK": "USER#196001198685",
  "provider": "VIVA",
  "SK": "USER#196001198685#CASE#ac48eedf-819f-4011-bbd8-da6cc2c8c5b4",
  "status": {

  },
  "updatedAt": 1611758051108
}
```

**By triggering event from Amazone event bridge:**
Event bus: default
Event source: bankId.collect
Detail type: BankIdCollectComplete
Event detail: { "user": { "personalNumber": "196001198685" } }
