### PR TITLE
Feat/set initial case answers

### DIFF
--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -160,13 +160,13 @@ const mergeAnswers = (previousAnswers, newAnswers) =>
  * @param {Object} forms
  * @param {Object} user
  * @param {Object} formTemplates
- * @param {Object} previousCase
+ * @param {Object} previousForms
  */
-export const populateFormWithPreviousCaseAnswers = (forms, user, formTemplates, previousCase) => {
+export const populateFormWithPreviousCaseAnswers = (forms, user, formTemplates, previousForms) => {
   const populatedForms = forms;
   Object.keys(forms).forEach(formId => {
     const formTemplate = formTemplates?.[formId] || {};
-    const previousAnswers = previousCase?.forms?.[formId]?.answers || [];
+    const previousAnswers = previousForms?.[formId]?.answers || [];
     const dataMap = generateDataMap(formTemplate);
     const answers = populateAnswers(dataMap, user, previousAnswers);
     const mergedAnswers = mergeAnswers(answers, forms[formId].answers);

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -1,297 +1,115 @@
 const getLatestCase = {
-  195405272260: {
-    createdAt: 1615989505899,
-    currentFormId: 'bf0ce700-8633-11eb-aeb9-891ddc9690af',
-    details: {},
-    expirationTime: 1616248996,
-    forms: {
-      'bf0ce700-8633-11eb-aeb9-891ddc9690af': {
-        answers: [
-          {
-            field: {
-              id: 'name',
-              tags: ['nametag', 'someothertag'],
-            },
-            value: 'Hanna',
-          },
-          {
-            field: {
-              id: 'id1234',
-              tags: [],
-            },
-            value: 'Vanligt textfält',
-          },
-          {
-            field: {
-              id: 'addressid123',
-              tags: [],
-            },
-            value: 'RINGVÄGEN 29',
-          },
-          {
-            field: {
-              id: 'emailid123',
-              tags: [],
-            },
-            value: 'Email@test.se',
-          },
-          {
-            field: {
-              id: 'editablelistid123.editinput1',
-              tags: ['editabletag', 'moretag'],
-            },
-            value: 'Test input 1',
-          },
-          {
-            field: {
-              id: 'editablelistid123.editinput2',
-              tags: [],
-            },
-            value: 'Test input 2',
-          },
-          {
-            field: {
-              id: 'check1',
-              tags: [],
-            },
-            value: true,
-          },
-          {
-            field: {
-              id: 'repeid97646.0.id111',
-              tags: ['taghere'],
-            },
-            value: 'Text here',
-          },
-          {
-            field: {
-              id: 'repeid97646.0.id22',
-              tags: ['heheh'],
-            },
-            value: '99',
-          },
-          {
-            field: {
-              id: 'repeid97646.1.id111',
-              tags: ['taghere'],
-            },
-            value: 'More text',
-          },
-          {
-            field: {
-              id: 'repeid97646.1.id22',
-              tags: ['heheh'],
-            },
-            value: '1337',
-          },
-        ],
-        currentPosition: {
-          currentMainStep: 1,
-          currentMainStepIndex: 0,
-          index: 0,
-          level: 0,
-        },
-      },
-    },
-    id: '90ac096d-66b5-4aa3-9bd4-762763f52e9e',
-    PK: 'USER#195405272260',
-    provider: 'VIVA',
-    SK: 'USER#195405272260#CASE#90ac096d-66b5-4aa3-9bd4-762763f52e9e',
-    status: {
-      description:
-        'Du har påbörjat en ansökan. Du kan öppna din ansökan och fortsätta där du slutade.',
-      name: 'Pågående',
-      type: 'active:ongoing',
-    },
-    updatedAt: 1615989795048,
-  },
-};
-
-const getForm = {
-  'bf0ce700-8633-11eb-aeb9-891ddc9690af': {
-    connectivityMatrix: [['none']],
-    createdAt: 1615884237168,
-    description: 'Initial answers test',
-    formType: 'EKB-recurring',
-    id: 'bf0ce700-8633-11eb-aeb9-891ddc9690af',
-    name: 'Initial answers',
-    PK: 'FORM#bf0ce700-8633-11eb-aeb9-891ddc9690af',
-    provider: 'VIVA',
-    steps: [
-      {
-        actions: [
-          {
-            color: 'blue',
-            hasCondition: false,
-            label: 'Submit',
-            type: 'sign',
-          },
-        ],
-        banner: {
-          backgroundColor: '',
-          iconSrc: '',
-          imageSrc: '',
-        },
-        colorSchema: 'blue',
-        description: '',
-        group: '',
-        id: '2d31d49c-d3ba-47a1-b791-bed0bfdeaf50',
-        questions: [
-          {
-            description: 'name',
-            hasCondition: false,
+  createdAt: 1615989505899,
+  currentFormId: 'bf0ce700-8633-11eb-aeb9-891ddc9690af',
+  details: {},
+  expirationTime: 1616248996,
+  forms: {
+    'bf0ce700-8633-11eb-aeb9-891ddc9690af': {
+      answers: [
+        {
+          field: {
             id: 'name',
-            inputSelectValue: 'text',
-            label: 'Name',
-            loadPrevious: ['name', 'user.firstName'],
-            showHelp: false,
             tags: ['nametag', 'someothertag'],
-            type: 'text',
-            validation: {
-              isRequired: false,
-              rules: [],
-            },
           },
-          {
-            description: 'other field',
+          value: 'Hanna',
+        },
+        {
+          field: {
             id: 'id1234',
-            inputSelectValue: 'text',
-            label: 'Textfield load previos from case',
-            loadPrevious: ['id1234'],
-            type: 'text',
-            validation: {
-              isRequired: false,
-              rules: [],
-            },
+            tags: [],
           },
-          {
-            description: 'Adress',
+          value: 'Vanligt textfält',
+        },
+        {
+          field: {
             id: 'addressid123',
-            inputSelectValue: 'text',
-            label: 'Adress',
-            loadPrevious: ['user.address.street'],
-            type: 'text',
-            validation: {
-              isRequired: false,
-              rules: [],
-            },
+            tags: [],
           },
-          {
-            description: 'email',
+          value: 'RINGVÄGEN 29',
+        },
+        {
+          field: {
             id: 'emailid123',
-            inputSelectValue: 'email',
-            label: 'Email',
-            loadPrevious: ['emailid123'],
-            type: 'text',
-            validation: {
-              isRequired: false,
-              rules: [
-                {
-                  message: 'Du måste ange en giltig emailadress',
-                  method: 'isEmail',
-                  validWhen: true,
-                },
-              ],
-            },
+            tags: [],
           },
-          {
-            description: '',
-            id: 'editablelistid123',
-            inputs: [
-              {
-                key: 'editinput1',
-                label: 'editable input 1',
-                loadPrevious: ['editinput1'],
-                tags: ['editabletag', 'moretag'],
-              },
-              {
-                key: 'editinput2',
-                label: 'editable input 2',
-                loadPrevious: ['editinput2'],
-              },
-            ],
-            inputSelectValue: 'editableList',
-            label: 'Editable list',
-            type: 'editableList',
+          value: 'Email@test.se',
+        },
+        {
+          field: {
+            id: 'editablelistid123.editinput1',
+            tags: ['editabletag', 'moretag'],
           },
-          {
-            description: '',
+          value: 'Test input 1',
+        },
+        {
+          field: {
+            id: 'editablelistid123.editinput2',
+            tags: [],
+          },
+          value: 'Test input 2',
+        },
+        {
+          field: {
             id: 'check1',
-            inputSelectValue: 'checkbox',
-            label: 'CHeckboc',
-            loadPrevious: ['check1'],
-            type: 'checkbox',
-            validation: {
-              isRequired: false,
-              rules: [],
-            },
+            tags: [],
           },
-          {
-            addButtonText: 'Add',
-            color: 'green',
-            description: '',
-            heading: 'repeater list heading',
-            id: 'repeid97646',
-            inputs: [
-              {
-                id: 'id111',
-                inputSelectValue: 'text',
-                tags: ['taghere'],
-                title: 'title 1',
-                type: 'text',
-                validation: {
-                  isRequired: false,
-                  rules: [],
-                },
-              },
-              {
-                id: 'id22',
-                inputSelectValue: 'number',
-                tags: ['heheh'],
-                title: 'title 2',
-                type: 'number',
-                validation: {
-                  isRequired: false,
-                  rules: [
-                    {
-                      args: {
-                        options: {
-                          no_symbols: true,
-                        },
-                      },
-                      message: 'Du måste ange en siffra',
-                      method: 'isNumeric',
-                      validWhen: true,
-                    },
-                  ],
-                },
-              },
-            ],
-            inputSelectValue: 'repeaterField',
-            label: 'Repeater',
-            loadPrevious: ['repeid97646'],
-            maxRows: 5,
-            type: 'repeaterField',
+          value: true,
+        },
+        {
+          field: {
+            id: 'repeid97646.0.id111',
+            tags: ['taghere'],
           },
-        ],
-        title: 'Step 1',
+          value: 'Text here',
+        },
+        {
+          field: {
+            id: 'repeid97646.0.id22',
+            tags: ['heheh'],
+          },
+          value: '99',
+        },
+        {
+          field: {
+            id: 'repeid97646.1.id111',
+            tags: ['taghere'],
+          },
+          value: 'More text',
+        },
+        {
+          field: {
+            id: 'repeid97646.1.id22',
+            tags: ['heheh'],
+          },
+          value: '1337',
+        },
+      ],
+      currentPosition: {
+        currentMainStep: 1,
+        currentMainStepIndex: 0,
+        index: 0,
+        level: 0,
       },
-    ],
-    stepStructure: [
-      {
-        children: [],
-        group: '9b613e38-423d-4e3f-8306-d085425827d6',
-        id: '2d31d49c-d3ba-47a1-b791-bed0bfdeaf50',
-        text: 'Step 1',
-      },
-    ],
-    subform: false,
-    updatedAt: 1615884237168,
+    },
   },
+  id: '90ac096d-66b5-4aa3-9bd4-762763f52e9e',
+  PK: 'USER#195405272260',
+  provider: 'VIVA',
+  SK: 'USER#195405272260#CASE#90ac096d-66b5-4aa3-9bd4-762763f52e9e',
+  status: {
+    description:
+      'Du har påbörjat en ansökan. Du kan öppna din ansökan och fortsätta där du slutade.',
+    name: 'Pågående',
+    type: 'active:ongoing',
+  },
+  updatedAt: 1615989795048,
 };
 
 const generateDataMap = form => {
   const dataMap = [];
+  if (!form.steps) {
+    return dataMap;
+  }
 
   form.steps.forEach(({ questions }) => {
     if (!questions) {
@@ -425,18 +243,15 @@ const populateAnswers = (dataMap, user, previousFormAnswers) => {
   return answers;
 };
 
-export const populateFormAnswers = (forms, user, personalNumber) => {
+export const populateFormAnswers = (forms, user, formTemplates) => {
   const initialForms = { ...forms };
-
   Object.keys(initialForms).forEach(formId => {
-    // TODO: Replace fake methods
-    const formObject = getForm[formId];
-    const latestCase = getLatestCase[personalNumber];
+    const formTemplate = formTemplates[formId] || {};
+    // MOCK
+    const latestCase = getLatestCase;
     const previousFormAnswers = latestCase.forms[formId].answers || [];
-    console.log('previousFormAnswers', previousFormAnswers);
 
-    const dataMap = generateDataMap(formObject);
-    console.log('dataMap', dataMap);
+    const dataMap = generateDataMap(formTemplate);
 
     const answers = populateAnswers(dataMap, user, previousFormAnswers);
     initialForms[formId].answers = answers;

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -107,23 +107,6 @@ const getLatestCase = {
   },
 };
 
-const getUser = {
-  195405272260: {
-    address: {
-      postalCode: '11863',
-      street: 'RINGVÄGEN 29',
-    },
-    civilStatus: 'S',
-    createdAt: 1615814772250,
-    email: null,
-    firstName: 'Hanna',
-    lastName: 'Hagströmer',
-    mobilePhone: null,
-    personalNumber: '195405272260',
-    uuid: '02bb97a0-8592-11eb-9927-69631b3e3f7b',
-  },
-};
-
 const getForm = {
   'bf0ce700-8633-11eb-aeb9-891ddc9690af': {
     connectivityMatrix: [['none']],
@@ -442,11 +425,12 @@ const populateAnswers = (dataMap, user, previousFormAnswers) => {
   return answers;
 };
 
-export const populateFormAnswers = (forms, personalNumber) =>
-  Object.keys(forms).map(formId => {
+export const populateFormAnswers = (forms, user, personalNumber) => {
+  const initialForms = { ...forms };
+
+  Object.keys(initialForms).forEach(formId => {
     // TODO: Replace fake methods
     const formObject = getForm[formId];
-    const user = getUser[personalNumber];
     const latestCase = getLatestCase[personalNumber];
     const previousFormAnswers = latestCase.forms[formId].answers || [];
     console.log('previousFormAnswers', previousFormAnswers);
@@ -455,5 +439,8 @@ export const populateFormAnswers = (forms, personalNumber) =>
     console.log('dataMap', dataMap);
 
     const answers = populateAnswers(dataMap, user, previousFormAnswers);
-    return { ...forms, answers };
+    initialForms[formId].answers = answers;
   });
+
+  return initialForms;
+};

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -142,11 +142,6 @@ function populateAnswers(dataMap, user, previousAnswers) {
   return answers;
 }
 
-/**
- * Merges previous answers with new answers. New answers will override previous ones.
- * @param {array} previousAnswers
- * @param {array} newAnswers
- */
 function mergeAnswers(previousAnswers, newAnswers) {
   return Object.values(
     [...previousAnswers, ...newAnswers].reduce((result, current) => {
@@ -159,13 +154,6 @@ function mergeAnswers(previousAnswers, newAnswers) {
   );
 }
 
-/**
- * Takes a form object and populate it with previous answers and user information
- * @param {Object} forms
- * @param {Object} user
- * @param {Object} formTemplates
- * @param {Object} previousForms
- */
 export function populateFormWithPreviousCaseAnswers(forms, user, formTemplates, previousForms) {
   const populatedForms = forms;
   Object.keys(forms).forEach(formId => {

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -64,7 +64,7 @@ const generateDataMap = form => {
   return dataMap;
 };
 
-const formatAnswer = (id, tags, value) => ({ field: { id, tags }, value });
+const formatAnswer = (id, tags, value) => ({ field: { id, tags: tags || [] }, value });
 
 const getUserInfo = (user, strArray) =>
   strArray.reduce((prev, current) => {

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -162,7 +162,7 @@ const mergeAnswers = (previousAnswers, newAnswers) =>
  * @param {Object} formTemplates
  * @param {Object} previousCase
  */
-export const populateFormAnswers = (forms, user, formTemplates, previousCase) => {
+export const populateFormWithPreviousCaseAnswers = (forms, user, formTemplates, previousCase) => {
   const populatedForms = forms;
   Object.keys(forms).forEach(formId => {
     const formTemplate = formTemplates?.[formId] || {};

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -1,4 +1,4 @@
-const generateDataMap = form => {
+function generateDataMap(form) {
   const dataMap = [];
   if (!form.steps) {
     return dataMap;
@@ -62,24 +62,27 @@ const generateDataMap = form => {
   });
 
   return dataMap;
-};
+}
 
-const formatAnswer = (id, tags, value) => ({ field: { id, tags: tags || [] }, value });
+function formatAnswer(id, tags, value) {
+  return { field: { id, tags: tags || [] }, value };
+}
 
-const getUserInfo = (user, strArray) =>
-  strArray.reduce((prev, current) => {
+function getUserInfo(user, strArray) {
+  return strArray.reduce((prev, current) => {
     if (prev && prev[current]) {
       return prev[current];
     }
     return undefined;
   }, user);
+}
 
-const getCaseAnswer = (answers, matchString) => {
+function getCaseAnswer(answers, matchString) {
   const result = answers.find(obj => obj.field.id === matchString);
   return result?.value || undefined;
-};
+}
 
-const getMultipleFieldAnswers = (field, previousAnswers) => {
+function getMultipleFieldAnswers(field, previousAnswers) {
   const answers = [];
   if (!field.loadPrevious) {
     return answers;
@@ -98,9 +101,9 @@ const getMultipleFieldAnswers = (field, previousAnswers) => {
   });
 
   return answers;
-};
+}
 
-const getInitialValue = (field, user, previousAnswers) => {
+function getInitialValue(field, user, previousAnswers) {
   let initialValue;
 
   field.loadPrevious.forEach(matchString => {
@@ -115,9 +118,9 @@ const getInitialValue = (field, user, previousAnswers) => {
   });
 
   return initialValue ? formatAnswer(field.id, field.tags, initialValue) : undefined;
-};
+}
 
-const populateAnswers = (dataMap, user, previousAnswers) => {
+function populateAnswers(dataMap, user, previousAnswers) {
   const answers = [];
 
   dataMap.forEach(field => {
@@ -137,15 +140,15 @@ const populateAnswers = (dataMap, user, previousAnswers) => {
   });
 
   return answers;
-};
+}
 
 /**
  * Merges previous answers with new answers. New answers will override previous ones.
  * @param {array} previousAnswers
  * @param {array} newAnswers
  */
-const mergeAnswers = (previousAnswers, newAnswers) =>
-  Object.values(
+function mergeAnswers(previousAnswers, newAnswers) {
+  return Object.values(
     [...previousAnswers, ...newAnswers].reduce((result, current) => {
       result[current.field.id] = {
         ...(result[current.field.id] || {}),
@@ -154,6 +157,7 @@ const mergeAnswers = (previousAnswers, newAnswers) =>
       return result;
     }, {})
   );
+}
 
 /**
  * Takes a form object and populate it with previous answers and user information
@@ -162,7 +166,7 @@ const mergeAnswers = (previousAnswers, newAnswers) =>
  * @param {Object} formTemplates
  * @param {Object} previousForms
  */
-export const populateFormWithPreviousCaseAnswers = (forms, user, formTemplates, previousForms) => {
+export function populateFormWithPreviousCaseAnswers(forms, user, formTemplates, previousForms) {
   const populatedForms = forms;
   Object.keys(forms).forEach(formId => {
     const formTemplate = formTemplates?.[formId] || {};
@@ -174,4 +178,4 @@ export const populateFormWithPreviousCaseAnswers = (forms, user, formTemplates, 
   });
 
   return populatedForms;
-};
+}

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -105,8 +105,11 @@ const getInitialValue = (field, user, previousAnswers) => {
 
   field.loadPrevious.forEach(matchString => {
     const strArray = matchString.split('.');
-    if (strArray[0] === 'user' && (initialValue = getUserInfo(user, strArray.slice(1)))) {
-      return initialValue;
+    if (strArray[0] === 'user') {
+      initialValue = getUserInfo(user, strArray.slice(1)) || initialValue;
+      if (initialValue) {
+        return formatAnswer(field.id, field.tags, initialValue);
+      }
     }
     initialValue = getCaseAnswer(previousAnswers, matchString) || initialValue;
   });

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -155,14 +155,15 @@ function mergeAnswers(previousAnswers, newAnswers) {
 }
 
 export function populateFormWithPreviousCaseAnswers(forms, user, formTemplates, previousForms) {
-  const populatedForms = forms;
+  const populatedForms = {};
   Object.keys(forms).forEach(formId => {
+    const form = forms[formId];
     const formTemplate = formTemplates?.[formId] || {};
     const previousAnswers = previousForms?.[formId]?.answers || [];
     const dataMap = generateDataMap(formTemplate);
     const answers = populateAnswers(dataMap, user, previousAnswers);
     const mergedAnswers = mergeAnswers(answers, forms[formId].answers);
-    populatedForms[formId].answers = mergedAnswers;
+    populatedForms[formId] = { ...form, answers: mergedAnswers };
   });
 
   return populatedForms;

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -146,7 +146,7 @@ const mergeAnswers = (previousAnswers, newAnswers) =>
     [...previousAnswers, ...newAnswers].reduce((result, current) => {
       result[current.field.id] = {
         ...(result[current.field.id] || {}),
-        current,
+        ...current,
       };
       return result;
     }, {})

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -79,7 +79,7 @@ const getCaseAnswer = (answers, matchString) => {
   return result?.value || undefined;
 };
 
-const getMultipleFieldValues = (field, previousAnswers) => {
+const getMultipleFieldAnswers = (field, previousAnswers) => {
   const answers = [];
   if (!field.loadPrevious) {
     return answers;
@@ -108,7 +108,6 @@ const getInitialValue = (field, user, previousAnswers) => {
     if (strArray[0] === 'user' && (initialValue = getUserInfo(user, strArray.slice(1)))) {
       return initialValue;
     }
-
     initialValue = getCaseAnswer(previousAnswers, matchString) || initialValue;
   });
 
@@ -120,7 +119,7 @@ const populateAnswers = (dataMap, user, previousAnswers) => {
 
   dataMap.forEach(field => {
     if (field.type === 'repeaterField') {
-      const repeaterAnswers = getMultipleFieldValues(field, previousAnswers);
+      const repeaterAnswers = getMultipleFieldAnswers(field, previousAnswers);
       if (repeaterAnswers.length > 0) {
         answers.push(...repeaterAnswers);
       }
@@ -147,7 +146,7 @@ const populateAnswers = (dataMap, user, previousAnswers) => {
 export const populateFormAnswers = (forms, user, formTemplates, previousCase) => {
   const populatedForms = forms;
   Object.keys(forms).forEach(formId => {
-    const formTemplate = formTemplates[formId] || {};
+    const formTemplate = formTemplates?.[formId] || {};
     const previousAnswers = previousCase?.forms?.[formId]?.answers || [];
     const dataMap = generateDataMap(formTemplate);
     const answers = populateAnswers(dataMap, user, previousAnswers);

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -1,0 +1,459 @@
+const getLatestCase = {
+  195405272260: {
+    createdAt: 1615989505899,
+    currentFormId: 'bf0ce700-8633-11eb-aeb9-891ddc9690af',
+    details: {},
+    expirationTime: 1616248996,
+    forms: {
+      'bf0ce700-8633-11eb-aeb9-891ddc9690af': {
+        answers: [
+          {
+            field: {
+              id: 'name',
+              tags: ['nametag', 'someothertag'],
+            },
+            value: 'Hanna',
+          },
+          {
+            field: {
+              id: 'id1234',
+              tags: [],
+            },
+            value: 'Vanligt textfält',
+          },
+          {
+            field: {
+              id: 'addressid123',
+              tags: [],
+            },
+            value: 'RINGVÄGEN 29',
+          },
+          {
+            field: {
+              id: 'emailid123',
+              tags: [],
+            },
+            value: 'Email@test.se',
+          },
+          {
+            field: {
+              id: 'editablelistid123.editinput1',
+              tags: ['editabletag', 'moretag'],
+            },
+            value: 'Test input 1',
+          },
+          {
+            field: {
+              id: 'editablelistid123.editinput2',
+              tags: [],
+            },
+            value: 'Test input 2',
+          },
+          {
+            field: {
+              id: 'check1',
+              tags: [],
+            },
+            value: true,
+          },
+          {
+            field: {
+              id: 'repeid97646.0.id111',
+              tags: ['taghere'],
+            },
+            value: 'Text here',
+          },
+          {
+            field: {
+              id: 'repeid97646.0.id22',
+              tags: ['heheh'],
+            },
+            value: '99',
+          },
+          {
+            field: {
+              id: 'repeid97646.1.id111',
+              tags: ['taghere'],
+            },
+            value: 'More text',
+          },
+          {
+            field: {
+              id: 'repeid97646.1.id22',
+              tags: ['heheh'],
+            },
+            value: '1337',
+          },
+        ],
+        currentPosition: {
+          currentMainStep: 1,
+          currentMainStepIndex: 0,
+          index: 0,
+          level: 0,
+        },
+      },
+    },
+    id: '90ac096d-66b5-4aa3-9bd4-762763f52e9e',
+    PK: 'USER#195405272260',
+    provider: 'VIVA',
+    SK: 'USER#195405272260#CASE#90ac096d-66b5-4aa3-9bd4-762763f52e9e',
+    status: {
+      description:
+        'Du har påbörjat en ansökan. Du kan öppna din ansökan och fortsätta där du slutade.',
+      name: 'Pågående',
+      type: 'active:ongoing',
+    },
+    updatedAt: 1615989795048,
+  },
+};
+
+const getUser = {
+  195405272260: {
+    address: {
+      postalCode: '11863',
+      street: 'RINGVÄGEN 29',
+    },
+    civilStatus: 'S',
+    createdAt: 1615814772250,
+    email: null,
+    firstName: 'Hanna',
+    lastName: 'Hagströmer',
+    mobilePhone: null,
+    personalNumber: '195405272260',
+    uuid: '02bb97a0-8592-11eb-9927-69631b3e3f7b',
+  },
+};
+
+const getForm = {
+  'bf0ce700-8633-11eb-aeb9-891ddc9690af': {
+    connectivityMatrix: [['none']],
+    createdAt: 1615884237168,
+    description: 'Initial answers test',
+    formType: 'EKB-recurring',
+    id: 'bf0ce700-8633-11eb-aeb9-891ddc9690af',
+    name: 'Initial answers',
+    PK: 'FORM#bf0ce700-8633-11eb-aeb9-891ddc9690af',
+    provider: 'VIVA',
+    steps: [
+      {
+        actions: [
+          {
+            color: 'blue',
+            hasCondition: false,
+            label: 'Submit',
+            type: 'sign',
+          },
+        ],
+        banner: {
+          backgroundColor: '',
+          iconSrc: '',
+          imageSrc: '',
+        },
+        colorSchema: 'blue',
+        description: '',
+        group: '',
+        id: '2d31d49c-d3ba-47a1-b791-bed0bfdeaf50',
+        questions: [
+          {
+            description: 'name',
+            hasCondition: false,
+            id: 'name',
+            inputSelectValue: 'text',
+            label: 'Name',
+            loadPrevious: ['name', 'user.firstName'],
+            showHelp: false,
+            tags: ['nametag', 'someothertag'],
+            type: 'text',
+            validation: {
+              isRequired: false,
+              rules: [],
+            },
+          },
+          {
+            description: 'other field',
+            id: 'id1234',
+            inputSelectValue: 'text',
+            label: 'Textfield load previos from case',
+            loadPrevious: ['id1234'],
+            type: 'text',
+            validation: {
+              isRequired: false,
+              rules: [],
+            },
+          },
+          {
+            description: 'Adress',
+            id: 'addressid123',
+            inputSelectValue: 'text',
+            label: 'Adress',
+            loadPrevious: ['user.address.street'],
+            type: 'text',
+            validation: {
+              isRequired: false,
+              rules: [],
+            },
+          },
+          {
+            description: 'email',
+            id: 'emailid123',
+            inputSelectValue: 'email',
+            label: 'Email',
+            loadPrevious: ['emailid123'],
+            type: 'text',
+            validation: {
+              isRequired: false,
+              rules: [
+                {
+                  message: 'Du måste ange en giltig emailadress',
+                  method: 'isEmail',
+                  validWhen: true,
+                },
+              ],
+            },
+          },
+          {
+            description: '',
+            id: 'editablelistid123',
+            inputs: [
+              {
+                key: 'editinput1',
+                label: 'editable input 1',
+                loadPrevious: ['editinput1'],
+                tags: ['editabletag', 'moretag'],
+              },
+              {
+                key: 'editinput2',
+                label: 'editable input 2',
+                loadPrevious: ['editinput2'],
+              },
+            ],
+            inputSelectValue: 'editableList',
+            label: 'Editable list',
+            type: 'editableList',
+          },
+          {
+            description: '',
+            id: 'check1',
+            inputSelectValue: 'checkbox',
+            label: 'CHeckboc',
+            loadPrevious: ['check1'],
+            type: 'checkbox',
+            validation: {
+              isRequired: false,
+              rules: [],
+            },
+          },
+          {
+            addButtonText: 'Add',
+            color: 'green',
+            description: '',
+            heading: 'repeater list heading',
+            id: 'repeid97646',
+            inputs: [
+              {
+                id: 'id111',
+                inputSelectValue: 'text',
+                tags: ['taghere'],
+                title: 'title 1',
+                type: 'text',
+                validation: {
+                  isRequired: false,
+                  rules: [],
+                },
+              },
+              {
+                id: 'id22',
+                inputSelectValue: 'number',
+                tags: ['heheh'],
+                title: 'title 2',
+                type: 'number',
+                validation: {
+                  isRequired: false,
+                  rules: [
+                    {
+                      args: {
+                        options: {
+                          no_symbols: true,
+                        },
+                      },
+                      message: 'Du måste ange en siffra',
+                      method: 'isNumeric',
+                      validWhen: true,
+                    },
+                  ],
+                },
+              },
+            ],
+            inputSelectValue: 'repeaterField',
+            label: 'Repeater',
+            loadPrevious: ['repeid97646'],
+            maxRows: 5,
+            type: 'repeaterField',
+          },
+        ],
+        title: 'Step 1',
+      },
+    ],
+    stepStructure: [
+      {
+        children: [],
+        group: '9b613e38-423d-4e3f-8306-d085425827d6',
+        id: '2d31d49c-d3ba-47a1-b791-bed0bfdeaf50',
+        text: 'Step 1',
+      },
+    ],
+    subform: false,
+    updatedAt: 1615884237168,
+  },
+};
+
+const generateDataMap = form => {
+  const dataMap = [];
+
+  form.steps.forEach(({ questions }) => {
+    if (!questions) {
+      return;
+    }
+
+    questions.forEach(question => {
+      if (question.type === 'editableList' && question.inputs) {
+        question.inputs.forEach(input => {
+          if (input.loadPrevious) {
+            const inputId = `${question.id}.${input.key}`;
+            const loadPrevious = input.loadPrevious.map(value =>
+              value === input.key ? inputId : value
+            );
+
+            dataMap.push({
+              id: inputId,
+              loadPrevious: loadPrevious,
+              tags: input.tags,
+              type: question.type,
+            });
+          }
+        });
+
+        return;
+      }
+
+      if (question.type === 'repeaterField' && question.inputs) {
+        question.inputs.forEach(input => {
+          if (question.loadPrevious) {
+            const inputId = `${question.id}.[*].${input.id}`;
+            const loadPrevious = question.loadPrevious.map(value =>
+              value === question.id ? inputId : value
+            );
+
+            dataMap.push({
+              id: inputId,
+              loadPrevious: loadPrevious,
+              tags: input.tags,
+              type: question.type,
+            });
+          }
+        });
+
+        return;
+      }
+
+      if (question.loadPrevious) {
+        dataMap.push({
+          id: question.id,
+          loadPrevious: question.loadPrevious,
+          tags: question.tags,
+          type: question.type,
+        });
+      }
+    });
+  });
+
+  return dataMap;
+};
+
+const formatAnswer = (id, tags, value) => ({ field: { id, tags }, value });
+
+const getUserInfo = (user, strArray) =>
+  strArray.reduce((prev, current) => {
+    if (prev && prev[current]) {
+      return prev[current];
+    }
+    return undefined;
+  }, user);
+
+const getCaseAnswer = (answers, matchString) => {
+  const result = answers.find(obj => obj.field.id === matchString);
+  return result?.value || undefined;
+};
+
+const getInitialRepeaterValues = (field, previousFormAnswers) => {
+  const repeaterAnswers = [];
+  field.loadPrevious.forEach(matchString => {
+    const repeaterRegex = new RegExp('.+.[*]..+');
+    if (repeaterRegex.test(matchString)) {
+      const strArray = matchString.split('.[*].');
+      const repeaterIdRegex = new RegExp(`${strArray[0]}.[0-9]+.${strArray[1]}`);
+      const previousRepeaterAnswers = previousFormAnswers.filter(obj =>
+        repeaterIdRegex.test(obj.field.id)
+      );
+      if (previousRepeaterAnswers.length > 0) {
+        previousRepeaterAnswers.map(answer => formatAnswer(answer.id, field.tags, answer.value));
+        repeaterAnswers.push(...previousRepeaterAnswers);
+      }
+    }
+  });
+
+  return repeaterAnswers;
+};
+
+const getInitialValue = (field, user, previousFormAnswers) => {
+  let initialValue;
+
+  field.loadPrevious.forEach(matchString => {
+    const strArray = matchString.split('.');
+    if (strArray[0] === 'user' && (initialValue = getUserInfo(user, strArray.slice(1)))) {
+      return initialValue;
+    }
+
+    initialValue = getCaseAnswer(previousFormAnswers, matchString) || initialValue;
+  });
+
+  return initialValue ? formatAnswer(field.id, field.tags, initialValue) : undefined;
+};
+
+const populateAnswers = (dataMap, user, previousFormAnswers) => {
+  const answers = [];
+
+  dataMap.forEach(field => {
+    if (field.type === 'repeaterField') {
+      const repeaterAnswers = getInitialRepeaterValues(field, previousFormAnswers);
+      if (repeaterAnswers.length > 0) {
+        answers.push(...repeaterAnswers);
+      }
+
+      return;
+    }
+
+    const initialFieldValue = getInitialValue(field, user, previousFormAnswers);
+    if (initialFieldValue) {
+      answers.push(initialFieldValue);
+    }
+  });
+
+  return answers;
+};
+
+export const populateFormAnswers = (forms, personalNumber) =>
+  Object.keys(forms).map(formId => {
+    // TODO: Replace fake methods
+    const formObject = getForm[formId];
+    const user = getUser[personalNumber];
+    const latestCase = getLatestCase[personalNumber];
+    const previousFormAnswers = latestCase.forms[formId].answers || [];
+    console.log('previousFormAnswers', previousFormAnswers);
+
+    const dataMap = generateDataMap(formObject);
+    console.log('dataMap', dataMap);
+
+    const answers = populateAnswers(dataMap, user, previousFormAnswers);
+    return { ...forms, answers };
+  });

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -137,6 +137,22 @@ const populateAnswers = (dataMap, user, previousAnswers) => {
 };
 
 /**
+ * Merges previous answers with new answers. New answers will override previous ones.
+ * @param {array} previousAnswers
+ * @param {array} newAnswers
+ */
+const mergeAnswers = (previousAnswers, newAnswers) =>
+  Object.values(
+    [...previousAnswers, ...newAnswers].reduce((result, current) => {
+      result[current.field.id] = {
+        ...(result[current.field.id] || {}),
+        current,
+      };
+      return result;
+    }, {})
+  );
+
+/**
  * Takes a form object and populate it with previous answers and user information
  * @param {Object} forms
  * @param {Object} user
@@ -150,7 +166,8 @@ export const populateFormAnswers = (forms, user, formTemplates, previousCase) =>
     const previousAnswers = previousCase?.forms?.[formId]?.answers || [];
     const dataMap = generateDataMap(formTemplate);
     const answers = populateAnswers(dataMap, user, previousAnswers);
-    populatedForms[formId].answers = answers;
+    const mergedAnswers = mergeAnswers(answers, forms[formId].answers);
+    populatedForms[formId].answers = mergedAnswers;
   });
 
   return populatedForms;

--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -45,7 +45,7 @@ export async function main(event) {
     initialForms,
     user,
     formTemplates,
-    previousCase
+    previousCase?.forms || {}
   );
 
   const timestampNow = Date.now();

--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -41,7 +41,7 @@ export async function main(event) {
   const user = await getUser(personalNumber);
   const formTemplates = await getFormTemplates(initialForms);
   const previousCase = await getLastUpdatedCase(PK, provider);
-  const preFilledForms = populateFormAnswers(initialForms, user, formTemplates, previousCase);
+  const prePopulatedForms = populateFormAnswers(initialForms, user, formTemplates, previousCase);
 
   const timestampNow = Date.now();
   const expirationTime = millisecondsToSeconds(getFutureTimestamp(CASE_EXPIRATION_HOURS));
@@ -54,7 +54,7 @@ export async function main(event) {
     currentFormId,
     provider,
     details,
-    forms: preFilledForms,
+    forms: prePopulatedForms,
     expirationTime,
     createdAt: timestampNow,
     updatedAt: timestampNow,

--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -38,7 +38,10 @@ export async function main(event) {
   const PK = `USER#${personalNumber}`;
   const SK = `USER#${personalNumber}#CASE#${id}`;
 
-  const user = await getUser(personalNumber);
+  const [userError, user] = await to(getUser(personalNumber));
+  if (userError) {
+    return response.failure(userError);
+  }
   const formTemplates = await getFormTemplates(initialForms);
   const previousCase = await getLastUpdatedCase(PK, provider);
   const prePopulatedForms = populateFormWithPreviousCaseAnswers(
@@ -127,8 +130,7 @@ async function getUser(personalNumber) {
 
   const [error, dbResponse] = await to(dynamoDb.call('get', params));
   if (!dbResponse) {
-    console.error('(cases-api) DynamoDb query on users table failed', error);
-    return;
+    throwError(error.statusCode, error.message);
   }
 
   return dbResponse.Item;

--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -134,7 +134,7 @@ async function getUser(personalNumber) {
   };
 
   const [error, dbResponse] = await to(dynamoDb.call('get', params));
-  if (!dbResponse) {
+  if (error) {
     throwError(error.statusCode, error.message);
   }
 
@@ -152,7 +152,7 @@ async function getFormTemplates(forms) {
     };
     const [error, dbResponse] = await to(dynamoDb.call('get', params));
 
-    if (!dbResponse) {
+    if (error) {
       console.error('(cases-api) DynamoDb query on forms table failed', error);
       continue;
     }
@@ -180,7 +180,7 @@ async function getLastUpdatedCase(PK, provider) {
   };
 
   const [error, dbResponse] = await to(dynamoDb.call('query', params));
-  if (!dbResponse) {
+  if (error) {
     throwError(error.statusCode, error.message);
   }
 

--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -1,3 +1,5 @@
+const util = require('util');
+
 import to from 'await-to-js';
 import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 import uuid from 'uuid';
@@ -7,6 +9,7 @@ import * as response from '../../../libs/response';
 import { decodeToken } from '../../../libs/token';
 import { getItem, putItem } from '../../../libs/queries';
 
+import { populateFormAnswers } from '../../../libs/formAnswers';
 import caseValidationSchema from '../helpers/schema';
 import { getFutureTimestamp, millisecondsToSeconds } from '../helpers/timestampHelper';
 import { getStatusByType } from '../../../libs/caseStatuses';
@@ -36,6 +39,9 @@ export async function main(event) {
   const PK = `USER#${personalNumber}`;
   const SK = `USER#${personalNumber}#CASE#${id}`;
 
+  const initialForms = populateFormAnswers(forms, personalNumber);
+  console.log(util.inspect(initialForms, { showHidden: false, depth: null }));
+
   const timestampNow = Date.now();
   const expirationTime = millisecondsToSeconds(getFutureTimestamp(CASE_EXPIRATION_HOURS));
 
@@ -47,7 +53,7 @@ export async function main(event) {
     currentFormId,
     provider,
     details,
-    forms,
+    forms: initialForms,
     expirationTime,
     createdAt: timestampNow,
     updatedAt: timestampNow,

--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -8,7 +8,7 @@ import * as response from '../../../libs/response';
 import { decodeToken } from '../../../libs/token';
 import { getItem, putItem } from '../../../libs/queries';
 
-import { populateFormAnswers } from '../../../libs/formAnswers';
+import { populateFormWithPreviousCaseAnswers } from '../../../libs/formAnswers';
 import caseValidationSchema from '../helpers/schema';
 import { getFutureTimestamp, millisecondsToSeconds } from '../helpers/timestampHelper';
 import { getStatusByType } from '../../../libs/caseStatuses';
@@ -41,7 +41,12 @@ export async function main(event) {
   const user = await getUser(personalNumber);
   const formTemplates = await getFormTemplates(initialForms);
   const previousCase = await getLastUpdatedCase(PK, provider);
-  const prePopulatedForms = populateFormAnswers(initialForms, user, formTemplates, previousCase);
+  const prePopulatedForms = populateFormWithPreviousCaseAnswers(
+    initialForms,
+    user,
+    formTemplates,
+    previousCase
+  );
 
   const timestampNow = Date.now();
   const expirationTime = millisecondsToSeconds(getFutureTimestamp(CASE_EXPIRATION_HOURS));

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -53,13 +53,13 @@ provider:
       Action:
         - dynamodb:Query
         - dynamodb:GetItem
-      # Restrict our IAM role permissions to the specific table for the stage
       Resource:
         - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
 
     - Effect: Allow
       Action:
         - dynamodb:Query
+        - dynamodb:GetItem
       Resource:
         - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
 

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -49,19 +49,19 @@ provider:
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-CasesTableArn
 
-    - Effect: Allow
-      Action:
-        - dynamodb:Query
-        - dynamodb:GetItem
-      Resource:
-        - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
+        - Effect: Allow
+          Action:
+            - dynamodb:Query
+            - dynamodb:GetItem
+          Resource:
+            - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
 
-    - Effect: Allow
-      Action:
-        - dynamodb:Query
-        - dynamodb:GetItem
-      Resource:
-        - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+        - Effect: Allow
+          Action:
+            - dynamodb:Query
+            - dynamodb:GetItem
+          Resource:
+            - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
 
 functions:
   getCase:

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -49,11 +49,19 @@ provider:
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-CasesTableArn
 
-        - Effect: Allow
-          Action:
-            - dynamodb:Query
-          Resource:
-            - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:GetItem
+      # Restrict our IAM role permissions to the specific table for the stage
+      Resource:
+        - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
+
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+      Resource:
+        - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
 
 functions:
   getCase:

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -162,39 +162,39 @@ async function putRecurringVivaCase(PK, workflowId, period) {
 async function getUser(PK) {
   const personalNumber = PK.replace('USER#', '');
   const params = {
-  const [error, dbResponse] = await to(dynamoDB.call('get', params));
-
-    },
     TableName: config.users.tableName,
     Key: {
-  };
       personalNumber,
+    },
+  };
+
+  const [error, dbResponse] = await to(dynamoDB.call('get', params));
   if (!dbResponse) {
     console.error('(cases-api) DynamoDb query on users table failed', error);
-  return dbResponse.Item;
-  }
     return;
+  }
 
+  return dbResponse.Item;
 }
-async function getFormTemplates(forms) {
 
+async function getFormTemplates(forms) {
   const formTemplates = {};
   for (const key of Object.keys(forms)) {
     const params = {
       TableName: config.forms.tableName,
       Key: {
         PK: `FORM#${key}`,
-    };
       },
-
+    };
     const [error, dbResponse] = await to(dynamoDB.call('get', params));
-    if (!dbResponse) {
-    formTemplates[key] = dbResponse.Item;
 
-      continue;
+    if (!dbResponse) {
       console.error('(cases-api) DynamoDb query on forms table failed', error);
+      continue;
     }
+    formTemplates[key] = dbResponse.Item;
   }
+
   return formTemplates;
 }
 
@@ -207,22 +207,21 @@ async function getLastUpdatedCase(PK, provider) {
       '#status': 'status',
       '#type': 'type',
       '#provider': 'provider',
-    ExpressionAttributeValues: {
     },
-      ':statusTypeClosed': 'closed',
+    ExpressionAttributeValues: {
       ':pk': PK,
+      ':statusTypeClosed': 'closed',
       ':provider': provider,
     },
   };
 
-}
-  return sortedCases?.[0] || {};
-
-  const sortedCases = dbResponse.Items.sort((a, b) => b.updatedAt - a.updatedAt);
-  }
-
-  if (!dbResponse) {
   const [error, dbResponse] = await to(dynamoDB.call('query', params));
-
+  if (!dbResponse) {
     console.error('(cases-api) DynamoDb query on cases table failed', error);
     return;
+  }
+
+  const sortedCases = dbResponse.Items.sort((a, b) => b.updatedAt - a.updatedAt);
+
+  return sortedCases?.[0] || {};
+}

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -183,7 +183,7 @@ async function getUser(PK) {
   };
 
   const [error, dbResponse] = await to(dynamoDB.call('get', params));
-  if (!dbResponse) {
+  if (error) {
     throwError(error.statusCode, error.message);
   }
 
@@ -201,7 +201,7 @@ async function getFormTemplates(forms) {
     };
     const [error, dbResponse] = await to(dynamoDB.call('get', params));
 
-    if (!dbResponse) {
+    if (error) {
       console.error('(cases-api) DynamoDb query on forms table failed', error);
       continue;
     }
@@ -229,7 +229,7 @@ async function getLastUpdatedCase(PK, provider) {
   };
 
   const [error, dbResponse] = await to(dynamoDB.call('query', params));
-  if (!dbResponse) {
+  if (error) {
     throwError(error.statusCode, error.message);
   }
 

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -134,7 +134,7 @@ async function putRecurringVivaCase(PK, workflowId, period) {
     initialForms,
     user,
     formTemplates,
-    previousCase
+    previousCase?.forms || {}
   );
 
   const putItemParams = {

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -9,7 +9,7 @@ import * as dynamoDB from '../../../libs/dynamoDb';
 import { CASE_PROVIDER_VIVA } from '../../../libs/constants';
 import { getStatusByType } from '../../../libs/caseStatuses';
 import validateApplicationStatus from '../helpers/validateApplicationStatus';
-import { populateFormAnswers } from '../../../libs/formAnswers';
+import { populateFormWithPreviousCaseAnswers } from '../../../libs/formAnswers';
 
 import vivaAdapter from '../helpers/vivaAdapterRequestClient';
 
@@ -130,7 +130,12 @@ async function putRecurringVivaCase(PK, workflowId, period) {
   const user = await getUser(PK);
   const formTemplates = await getFormTemplates(initialForms);
   const previousCase = await getLastUpdatedCase(PK, CASE_PROVIDER_VIVA);
-  const prePopulatedForms = populateFormAnswers(initialForms, user, formTemplates, previousCase);
+  const prePopulatedForms = populateFormWithPreviousCaseAnswers(
+    initialForms,
+    user,
+    formTemplates,
+    previousCase
+  );
 
   const putItemParams = {
     TableName: config.cases.tableName,

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -62,6 +62,20 @@ provider:
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-CasesTableArn
 
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:GetItem
+      Resource:
+        - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
+
+    - Effect: Allow
+      Action:
+        - dynamodb:Query
+        - dynamodb:GetItem
+      Resource:
+        - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+
 functions:
   submitApplication:
     handler: lambdas/submitApplication.main

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -62,19 +62,19 @@ provider:
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-CasesTableArn
 
-    - Effect: Allow
-      Action:
-        - dynamodb:Query
-        - dynamodb:GetItem
-      Resource:
-        - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
+        - Effect: Allow
+          Action:
+            - dynamodb:Query
+            - dynamodb:GetItem
+          Resource:
+            - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
 
-    - Effect: Allow
-      Action:
-        - dynamodb:Query
-        - dynamodb:GetItem
-      Resource:
-        - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+        - Effect: Allow
+          Action:
+            - dynamodb:Query
+            - dynamodb:GetItem
+          Resource:
+            - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
 
 functions:
   submitApplication:


### PR DESCRIPTION
## Explain the changes you’ve made
Added functionality to pre populate case answers with previous case answers and user information. 

## Explain your solution
Created a method that takes four arguments (initial forms, user object, previous case & form templates) and populates the initial forms with previous case data and user data. 
Which fields that will be pre populated can be defined from the formbuilder.

**Note** that the feature to load previous data is only activated to some of the fields(text, number, checkbox, repeaterField and editableList) in the formbuilder and will not work for rest of the fields. I'm not sure why we don't have it activated for all fields, could be a future task to fix. 

This new functionality is used by createCase + createVivaCase lambdas during the creation of new cases.

I have chosen to get previous case data from the latest updated case that also has status set to "closed". So this will not get previous answers from "ongoing" cases for example.

## How to test the changes?

First make sure you have a user, forms and a case(with status: closed) in your DB.
The form needs to have fields with "load previous" functionality activated. 

Deploy case and viva services. 
Make a POST request to create case endpoint.
Example body json:
`
{
  "statusType": "notStarted",
  "currentFormId": "SOME-FORM-ID",
  "provider": "VIVA",
  "details": {},
  "forms": {
    "SOME-FORM-ID {
      "answers": [],
      "currentPosition": {
        "index": 1,
        "level": 0,
        "currentMainStep": 0,
        "currentMainStepIndex": 0
      }
    }
  }
}
` 

If everything works the answers object should be populated with the data you have defined in form builder.  

## Anything else
I have only tested this with the createCase endpoint, because I dont know how to trigger event that creates a new VIVA case. So it would be great if someone could test that too.

