### PR TITLE
feat(navet-ms): abort navet request if user data is confidential

### DIFF
--- a/services/navet-ms/lambdas/pollUser.js
+++ b/services/navet-ms/lambdas/pollUser.js
@@ -66,9 +66,8 @@ async function requestNavetUser(payload, params) {
   if (
     Folkbokforingspost.Sekretessmarkering === 'J' ||
     Folkbokforingspost.SkyddadFolkbokforing === 'J'
-  ) {
-    throwError(404);
-  }
+  )
+    throw 'Forbidden';
 
   // Collect the user data from response
   const navetUserData = Folkbokforingspost.Personpost;

--- a/services/navet-ms/lambdas/pollUser.js
+++ b/services/navet-ms/lambdas/pollUser.js
@@ -66,8 +66,9 @@ async function requestNavetUser(payload, params) {
   if (
     Folkbokforingspost.Sekretessmarkering === 'J' ||
     Folkbokforingspost.SkyddadFolkbokforing === 'J'
-  )
-    throw 'Forbidden';
+  ) {
+    throw new Error('User is not allowed to use the service.');
+  }
 
   // Collect the user data from response
   const navetUserData = Folkbokforingspost.Personpost;

--- a/services/navet-ms/lambdas/pollUser.js
+++ b/services/navet-ms/lambdas/pollUser.js
@@ -60,8 +60,18 @@ async function requestNavetUser(payload, params) {
   [err, parsedData] = await to(parseJSON(navetUser.data));
   if (err) throwError(500);
 
+  const { Folkbokforingspost } = parsedData;
+
+  // Abort if user data is confidential
+  if (
+    Folkbokforingspost.Sekretessmarkering === 'J' ||
+    Folkbokforingspost.SkyddadFolkbokforing === 'J'
+  ) {
+    throwError(404);
+  }
+
   // Collect the user data from response
-  const navetUserData = parsedData.Folkbokforingspost.Personpost;
+  const navetUserData = Folkbokforingspost.Personpost;
   if (navetUserData === undefined) throwError(500);
 
   return navetUserData;


### PR DESCRIPTION
Stops confidential/protected identity users from being added to our database.

Try to login with a personal number that is marked as confidential, for example 197612222385. And it will return a 404 because the user cannot be found in DB. 
More Navet test users can be found in the attached file here: https://app.clickup.com/t/e91aa9
