### PR TITLE
feat: add decrypt access cu-g31bmk

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,3 @@ Distributed under the [MIT License][license-url].
 [issues-url]: https://github.com/helsingborg-stad/helsingborg-io-sls-api/issues
 [license-shield]: https://img.shields.io/github/license/helsingborg-stad/helsingborg-io-sls-api.svg?style=flat-square
 [license-url]: https://raw.githubusercontent.com/helsingborg-stad/helsingborg-io-sls-api/master/LICENSE
-[product-screenshot]: images/screenshot.png

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -62,6 +62,10 @@ provider:
             - dynamodb:GetItem
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+        - Effect: Allow
+          Action:
+            - kms:decrypt
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:
   getCase:

--- a/services/pdf-ms/serverless.yml
+++ b/services/pdf-ms/serverless.yml
@@ -69,6 +69,10 @@ provider:
                 - ""
                 - - Fn::ImportValue: ${self:custom.resourcesStage}-PdfTemplatesBucketArn
                   - "/*"
+        - Effect: Allow
+          Action:
+            - kms:decrypt
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:
   addPdfToCase:

--- a/services/stream-eventbridge-ms/serverless.yml
+++ b/services/stream-eventbridge-ms/serverless.yml
@@ -38,6 +38,10 @@ provider:
           # Restrict our IAM role permissions to the specific table for the stage
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-CasesTableArn
+        - Effect: Allow
+          Action:
+            - kms:decrypt
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:
   streamProcessor:

--- a/services/users-api/serverless.yml
+++ b/services/users-api/serverless.yml
@@ -60,6 +60,10 @@ provider:
                 - ""
                 - - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
                   - "/*"
+        - Effect: Allow
+          Action:
+            - kms:decrypt
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:
   getUser:

--- a/services/users-ms/serverless.yml
+++ b/services/users-ms/serverless.yml
@@ -33,6 +33,10 @@ provider:
           # Restrict our IAM role permissions to the specific table for the stage
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
+        - Effect: Allow
+          Action:
+            - kms:decrypt
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:
   create:

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -77,6 +77,10 @@ provider:
             - dynamodb:GetItem
           Resource:
             - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+        - Effect: Allow
+          Action:
+            - kms:decrypt
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:
   submitApplication:


### PR DESCRIPTION
## Feature description
Adds access to KMS CMK for decryption to lambdas that speaks to encrypted tables users and cases and S3 attachments.

## Solution description
Add IAM permission

## What areas is affected by these changes?.
Infrastructure

## Is there any excisting behavior change of other features due to this code change?
No

## Covered unit tests cases / E2E test cases?
no

## Was this feature tested in the following environments?
- [x] Your personal AWS environment.
- [ ] Your local Serverless environment.