### PR TITLE
fix(submitcompletion): setting attachment name to uploadedFilename

### DIFF
--- a/services/viva-ms/lambdas/submitCompletion.js
+++ b/services/viva-ms/lambdas/submitCompletion.js
@@ -96,7 +96,7 @@ async function answersToAttachmentList(personalNumber, answerList) {
 
       const attachment = {
         id: s3FileKey,
-        name: valueItem.filename,
+        name: valueItem.uploadedFileName,
         category: attachmentCategory,
         fileBase64: file.Body.toString('base64'),
       };


### PR DESCRIPTION
The filename attribute that is passed from the client to an item in DynamoDB Cases Table, was not
always set due to limit in the image library that is used. Since the viva adapter requires a name to
be passed on an attachment it would break. To fix this issue we now use the name of the uploaded
file in s3 instead, since that value will never be null