### PR TITLE
Feat/case initial expire time

### DIFF
--- a/libs/constants.js
+++ b/libs/constants.js
@@ -14,3 +14,4 @@ export const CASE_PROVIDER_VIVA = 'VIVA';
 export const DELETE_VIVA_CASE_AFTER_6_MONTH = 4382;
 export const DELETE_VIVA_CASE_AFTER_45_DAYS = 1080; // 45 days * 24 hours = 1080 hours
 export const DELETE_VIVA_CASE_AFTER_72_HOURS = 72;
+export const DELETE_VIVA_CASE_AFTER_12_HOURS = 12;

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -182,7 +182,7 @@ async function putRecurringVivaCase(PK, workflowId, period) {
 }
 
 async function getUser(PK) {
-  const personalNumber = PK.replace('USER#', '');
+  const personalNumber = PK.substring(5);
   const params = {
     TableName: config.users.tableName,
     Key: {

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -12,6 +12,9 @@ import { getStatusByType } from '../../../libs/caseStatuses';
 import validateApplicationStatus from '../helpers/validateApplicationStatus';
 import { populateFormWithPreviousCaseAnswers } from '../../../libs/formAnswers';
 
+import { getFutureTimestamp, millisecondsToSeconds } from '../../../libs/timestampHelper';
+import { DELETE_VIVA_CASE_AFTER_72_HOURS } from '../../../libs/constants';
+
 import vivaAdapter from '../helpers/vivaAdapterRequestClient';
 
 const VIVA_CASE_SSM_PARAMS = params.read(config.cases.providers.viva.envsKeyName);
@@ -148,11 +151,14 @@ async function putRecurringVivaCase(PK, workflowId, period) {
     previousCase?.forms || {}
   );
 
+  const expirationTime = millisecondsToSeconds(getFutureTimestamp(DELETE_VIVA_CASE_AFTER_72_HOURS));
+
   const putItemParams = {
     TableName: config.cases.tableName,
     Item: {
       id,
       PK,
+      expirationTime,
       SK: `${PK}#CASE#${id}`,
       createdAt: timestampNow,
       updatedAt: timestampNow,

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -13,7 +13,7 @@ import validateApplicationStatus from '../helpers/validateApplicationStatus';
 import { populateFormWithPreviousCaseAnswers } from '../../../libs/formAnswers';
 
 import { getFutureTimestamp, millisecondsToSeconds } from '../../../libs/timestampHelper';
-import { DELETE_VIVA_CASE_AFTER_72_HOURS } from '../../../libs/constants';
+import { DELETE_VIVA_CASE_AFTER_12_HOURS } from '../../../libs/constants';
 
 import vivaAdapter from '../helpers/vivaAdapterRequestClient';
 
@@ -151,7 +151,7 @@ async function putRecurringVivaCase(PK, workflowId, period) {
     previousCase?.forms || {}
   );
 
-  const expirationTime = millisecondsToSeconds(getFutureTimestamp(DELETE_VIVA_CASE_AFTER_72_HOURS));
+  const expirationTime = millisecondsToSeconds(getFutureTimestamp(DELETE_VIVA_CASE_AFTER_12_HOURS));
 
   const putItemParams = {
     TableName: config.cases.tableName,


### PR DESCRIPTION
## Explain the changes you’ve made
* Added initial expirationTime when a viva case is created.
* Fixed inconsistency in retrieval of personalNumber from PK.

## Explain why these changes are made
These changes have been made to remove open cases that have not been started currently open for a users from being able to start an old case.

## Explain your solution
Calculated the expirationTime from the current point in time when a case is created to get a future timestamp for when the case should be deleted. This timestamp is set on the case when adding it to dynamodb, dynamodb then handles the deletion when the expiration time is surpassed.

## How to test the changes?
1. Checkout this branch.
2. Navigate to /services/viva-ms `yarn install`.
3. Deploy the microservice `sls deploy`.
4. Trigger the createVivaCase lambda by an eventbridge event to create a new case.

