### PR TITLE
Perf/update case status

### DIFF
--- a/libs/caseStatuses.js
+++ b/libs/caseStatuses.js
@@ -11,9 +11,9 @@ const statuses = [
       'Du har påbörjat en ansökan. Du kan öppna din ansökan och fortsätta där du slutade.',
   },
   {
-    type: 'active:signed:viva',
+    type: 'active:signature:completed',
     name: 'Signerad',
-    description: 'Ansökan är signerad, ladda upp filer & dokument för att skicka in ansökan.',
+    description: 'Ansökan är signerad',
   },
   {
     type: 'active:submitted',

--- a/libs/caseStatuses.js
+++ b/libs/caseStatuses.js
@@ -11,7 +11,7 @@ const statuses = [
       'Du har påbörjat en ansökan. Du kan öppna din ansökan och fortsätta där du slutade.',
   },
   {
-    type: 'active:signature:completed',
+    type: 'active:signed',
     name: 'Signerad',
     description: 'Ansökan är signerad',
   },

--- a/services/cases-api/helpers/dynamo.js
+++ b/services/cases-api/helpers/dynamo.js
@@ -1,0 +1,19 @@
+import dynamoDb from '../../../libs';
+import config from '../../../config';
+
+export async function getCaseWhereUserIsApplicant(caseId, userPersonalNumber) {
+  const PK = `USER#${userPersonalNumber}`;
+  const SK = `${PK}#CASE#${caseId}`;
+
+  const dynamoDbQueryParams = {
+    TableName: config.cases.tableName,
+    ExpressionAttributeValues: {
+      ':pk': PK,
+      ':sk': SK,
+    },
+    KeyConditionExpression: 'PK = :pk AND SK = :sk',
+    Limit: 1,
+  };
+
+  return dynamoDb.call('query', dynamoDbQueryParams);
+}

--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -7,7 +7,7 @@ const uuid = Joi.string().guid({
 
 const caseProvider = Joi.string().valid(CASE_PROVIDER_VIVA);
 
-const caseAnswers = Joi.array().items(
+const answers = Joi.array().items(
   Joi.object({
     field: Joi.object({
       id: Joi.string().required(),
@@ -17,22 +17,39 @@ const caseAnswers = Joi.array().items(
   })
 );
 
+const encryptedAnswers = Joi.object({
+  encryptedAnswers: Joi.string(),
+});
+
+const formCurrentPosition = Joi.object({
+  index: Joi.number().required(),
+  level: Joi.number().required(),
+  currentMainStep: Joi.number().required(),
+  currentMainStepIndex: Joi.number().required(),
+});
+
+const signature = Joi.object({
+  success: Joi.bool().required(),
+});
+
 const form = Joi.object({
-  answers: caseAnswers.allow(),
-  currentPosition: Joi.object({
-    index: Joi.number().required(),
-    level: Joi.number().required(),
-    currentMainStep: Joi.number().required(),
-    currentMainStepIndex: Joi.number().required(),
-  }).required(),
+  answers: answers.allow(),
+  currentPosition: formCurrentPosition.required(),
 });
 
 const caseValidationSchema = Joi.object({
-  statusType: Joi.string().valid('notStarted').required(),
+  statusType: Joi.string().valid('notStarted'),
   currentFormId: uuid.required(),
   provider: caseProvider.required(),
   details: Joi.object().allow(),
   forms: Joi.object().pattern(/^/, [uuid.required(), form.required()]),
+});
+
+export const updateCaseValidationSchema = Joi.object({
+  currentFormId: uuid.required(),
+  answers: [answers.allow(), encryptedAnswers.allow()],
+  currentPosition: formCurrentPosition.required(),
+  signature: signature.optional(),
 });
 
 export default caseValidationSchema;

--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -179,19 +179,19 @@ function getNewCaseStatus(answers, signature) {
   return getStatusByType(statusType);
 }
 
-function isAnswersEncrypted(answers) {
+function areAnswersEncrypted(answers) {
   const keys = Object.keys(answers);
   return keys.length === 1 && keys.includes('encryptedAnswers');
 }
 
 function isOngoing(answers) {
-  return answers && isAnswersEncrypted(answers);
+  return answers && areAnswersEncrypted(answers);
 }
 
 function isSignatureCompleted(answers, signature) {
-  return signature.successfull && isAnswersEncrypted(answers);
+  return signature.success && areAnswersEncrypted(answers);
 }
 
 function isSubmitted(answers, signature) {
-  return signature.successfull && !isAnswersEncrypted(answers);
+  return signature.success && !areAnswersEncrypted(answers);
 }

--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -180,6 +180,11 @@ function getNewCaseStatus(answers, signature) {
 }
 
 function areAnswersEncrypted(answers) {
+  if (Array.isArray(answers)) {
+    // decrypted answers should allways be submitted as an flat array,
+    // if they are we assume the value to be decrypted and return false.
+    return false;
+  }
   const keys = Object.keys(answers);
   return keys.length === 1 && keys.includes('encryptedAnswers');
 }

--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -160,7 +160,7 @@ function getNewCaseStatus(answers, signature) {
       condition: isOngoing,
     },
     {
-      name: 'active:signature:completed',
+      name: 'active:signed',
       condition: isSignatureCompleted,
     },
     {


### PR DESCRIPTION
## Explain the changes you’ve made

Removed support for setting the status on a case from request attributes, the status is now instead dynamically set based on attributes in the request data.

## Explain why these changes are made
Added new status for case active:signature:completed
Checking if the case exists before trying to preform updates.
Added support for conditional retrieving of the case status based on answers and signatures attributes in the json payload.
Updating the case status if there is any new status to be retrieved.

## Explain your solution

Earlier we allowed the setting of a case status by passing a value on the attribute statusType
in the json payload, this behavior is now deprecated. 

Now instead the lambda looks on the data in the json payload to figure out if the case status should be updated and what that status is. 

The lambda can currently set three statuses on a case active:ongoing, active:signature:completed,
active:submitted based on the answers attribute and a new attribute called signature from the json
payload.

Statuses are set when a certain condition is true:
active:ongoing is set when answers in the payload are encrypted.
active:signature:completed is set when the answers in the payload are encrypted and a the signature is completed 
active:submitted is set when a answers are decrypted and the signature is completed.

## How to test the changes?

Concrete example:
1. Checkout this branch.
2. Recommended to use your own AWS sandbox environment.
3. Deploy the cases service.
4. Add/Create an initial case in your DynamoDB
5. Send put request towards /cases/{id} (id should be the id from your new case)

ongoing status
```JSON 
{
   answers: { encryptedAnswers: "an_encrypted_string"}
   signature: { successfull: false}
   ...
}
```

signature completed status
```JSON 
{
   answers: { encryptedAnswers: "an_encrypted_string"}
   signature: { successfull: true}
   ...
}
```

submitted status
```JSON 
{
   answers: [{...}, {...}]
   signature: { successfull: true}
   ...
}
```

## Was this feature tested in the following environments?
- [X] AWS Sandbox environment.

## Anything else
BREAKING CHANGE: All clients that uses the /cases with the PUT method will need to update their
requests in order to comply with these new changes.


