### PR TITLE
Feat/get cases gsi index

### DIFF
--- a/services/cases-api/lambdas/createCase.js
+++ b/services/cases-api/lambdas/createCase.js
@@ -34,7 +34,7 @@ export async function main(event) {
   const id = uuid.v4();
 
   const PK = `USER#${personalNumber}`;
-  const SK = `USER#${personalNumber}#CASE#${id}`;
+  const SK = `CASE#${id}`;
 
   const [userError, user] = await to(getUser(personalNumber));
   if (userError) {

--- a/services/cases-api/lambdas/deleteCase.js
+++ b/services/cases-api/lambdas/deleteCase.js
@@ -6,9 +6,6 @@ import * as response from '../../../libs/response';
 import { decodeToken } from '../../../libs/token';
 import * as dynamoDb from '../../../libs/dynamoDb';
 
-/**
- * Lambda deleting case by id from DynamoDB table cases
- */
 export async function main(event) {
   const decodedToken = decodeToken(event);
   const { id } = event.pathParameters;
@@ -17,7 +14,7 @@ export async function main(event) {
     TableName: config.cases.tableName,
     Key: {
       PK: `USER#${decodedToken.personalNumber}`,
-      SK: `USER#${decodedToken.personalNumber}#CASE#${id}`,
+      SK: `CASE#${id}`,
     },
     ConditionExpression: 'id = :caseId',
     ExpressionAttributeValues: {

--- a/services/cases-api/lambdas/getCase.js
+++ b/services/cases-api/lambdas/getCase.js
@@ -60,7 +60,7 @@ async function getUserCase(personalNumber, id) {
 
 async function getApplicantCase(personalNumber, id) {
   const PK = `USER#${personalNumber}`;
-  const SK = `USER#${personalNumber}#CASE#${id}`;
+  const SK = `CASE#${id}`;
 
   const params = {
     TableName: config.cases.tableName,
@@ -77,15 +77,15 @@ async function getApplicantCase(personalNumber, id) {
 
 async function getCoApplicantCase(personalNumber, id) {
   const GSI1 = `USER#${personalNumber}`;
+  const SK = `CASE#${id}`;
 
   const params = {
     TableName: config.cases.tableName,
     IndexName: 'GSI1-SK-index',
-    KeyConditionExpression: 'GSI1 = :gsi1',
-    FilterExpression: 'id = :id',
+    KeyConditionExpression: 'GSI1 = :gsi1 AND SK = :sk',
     ExpressionAttributeValues: {
       ':gsi1': GSI1,
-      ':id': id,
+      ':sk': SK,
     },
     Limit: 1,
   };

--- a/services/cases-api/lambdas/getCase.js
+++ b/services/cases-api/lambdas/getCase.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import to from 'await-to-js';
 import { throwError, ResourceNotFoundError } from '@helsingborg-stad/npm-api-error-handling';
 
@@ -11,46 +12,84 @@ export async function main(event) {
   const decodedToken = decodeToken(event);
   const { id } = event.pathParameters;
 
-  const { personalNumber } = decodedToken;
+  const [getUserCaseError, userCase] = await to(getUserCase(decodedToken.personalNumber, id));
+  console.log('userCase', userCase);
+  if (getUserCaseError) {
+    return response.failure(getUserCaseError);
+  }
 
+  if (userCase == undefined) {
+    return response.failure(new ResourceNotFoundError(`User case with id: ${id} not found`));
+  }
+
+  const userCaseWithoutPK_SK_GSI1 = objectWithoutProperties(userCase, ['PK', 'SK', 'GSI1']);
+
+  return response.success(200, {
+    type: 'getCase',
+    attributes: {
+      ...userCaseWithoutPK_SK_GSI1,
+    },
+  });
+}
+
+async function getUserCase(personalNumber, id) {
+  const [getApplicantCaseError, applicantCaseResult] = await to(
+    getApplicantCase(personalNumber, id)
+  );
+  if (getApplicantCaseError) {
+    console.error('getApplicantCaseError', getApplicantCaseError);
+    throwError(getApplicantCaseError.statusCode, getApplicantCaseError.message);
+  }
+
+  const [getCoApplicantCaseError, coApplicantCaseResult] = await to(
+    getCoApplicantCase(personalNumber, id)
+  );
+  if (getCoApplicantCaseError) {
+    console.error('getCoApplicantCaseError', getCoApplicantCaseError);
+    throwError(getCoApplicantCaseError.statusCode, getCoApplicantCaseError.message);
+  }
+
+  const concatAndDeDuplicateCase = (...userCases) => [...new Set([].concat(...userCases))];
+  const userCases = concatAndDeDuplicateCase(
+    applicantCaseResult.Items,
+    coApplicantCaseResult.Items
+  );
+
+  const [userCase] = userCases.filter(Boolean);
+  return userCase;
+}
+
+async function getApplicantCase(personalNumber, id) {
   const PK = `USER#${personalNumber}`;
   const SK = `USER#${personalNumber}#CASE#${id}`;
 
   const params = {
     TableName: config.cases.tableName,
+    KeyConditionExpression: 'PK = :pk AND SK = :sk',
     ExpressionAttributeValues: {
       ':pk': PK,
       ':sk': SK,
     },
-    KeyConditionExpression: 'PK = :pk AND SK = :sk',
     Limit: 1,
   };
 
-  const [caseDbError, caseDbResponse] = await to(sendCaseRequest(params));
-  if (caseDbError) {
-    return response.failure(caseDbError);
-  }
-
-  if (!caseDbResponse.Count) {
-    return response.failure(new ResourceNotFoundError(`Case with id: ${id} not found`));
-  }
-
-  const [item] = caseDbResponse.Items;
-  const attributes = objectWithoutProperties(item, ['PK', 'SK']);
-
-  return response.success(200, {
-    type: 'getCase',
-    attributes: {
-      ...attributes,
-    },
-  });
+  return dynamoDb.call('query', params);
 }
 
-async function sendCaseRequest(params) {
-  const [dynamoDbCallError, dynamoDbCallResult] = await to(dynamoDb.call('query', params));
-  if (dynamoDbCallError) {
-    throwError(dynamoDbCallError.statusCode, dynamoDbCallError.message);
-  }
+async function getCoApplicantCase(personalNumber, id) {
+  const GSI1 = `USER#${personalNumber}`;
 
-  return dynamoDbCallResult;
+  const params = {
+    TableName: config.cases.tableName,
+    IndexName: 'GSI1-SK-index',
+    KeyConditionExpression: 'GSI1 = :gsi1',
+    FilterExpression: 'id = :id',
+    ExpressionAttributeValues: {
+      ':gsi1': GSI1,
+      ':id': id,
+    },
+    Limit: 1,
+  };
+
+  return dynamoDb.call('query', params);
 }

--- a/services/cases-api/lambdas/getCase.js
+++ b/services/cases-api/lambdas/getCase.js
@@ -13,7 +13,6 @@ export async function main(event) {
   const { id } = event.pathParameters;
 
   const [getUserCaseError, userCase] = await to(getUserCase(decodedToken.personalNumber, id));
-  console.log('userCase', userCase);
   if (getUserCaseError) {
     return response.failure(getUserCaseError);
   }

--- a/services/cases-api/lambdas/getCaseList.js
+++ b/services/cases-api/lambdas/getCaseList.js
@@ -23,12 +23,14 @@ export async function main(event) {
     return response.failure(new ResourceNotFoundError('No user cases found'));
   }
 
-  const cases = userCases.map(item => objectWithoutProperties(item, ['PK', 'SK', 'GSI1']));
+  const userCasesWithoutPK_SK_GSI1 = userCases.map(item =>
+    objectWithoutProperties(item, ['PK', 'SK', 'GSI1'])
+  );
 
   return response.success(200, {
     type: 'getCases',
     attributes: {
-      cases,
+      cases: userCasesWithoutPK_SK_GSI1,
     },
   });
 }
@@ -56,7 +58,7 @@ async function getUserCases(personalNumber) {
 
 async function getApplicantCases(personalNumber) {
   const PK = `USER#${personalNumber}`;
-  const SK = PK;
+  const SK = 'CASE#';
 
   const params = {
     TableName: config.cases.tableName,
@@ -72,13 +74,15 @@ async function getApplicantCases(personalNumber) {
 
 async function getCoApplicantCases(personalNumber) {
   const GSI1 = `USER#${personalNumber}`;
+  const SK = 'CASE#';
 
   const params = {
     TableName: config.cases.tableName,
     IndexName: 'GSI1-SK-index',
-    KeyConditionExpression: 'GSI1 = :gsi1',
+    KeyConditionExpression: 'GSI1 = :gsi1 AND begins_with(SK, :sk)',
     ExpressionAttributeValues: {
       ':gsi1': GSI1,
+      ':sk': SK,
     },
   };
 

--- a/services/cases-api/lambdas/getCaseList.js
+++ b/services/cases-api/lambdas/getCaseList.js
@@ -13,50 +13,53 @@ export async function main(event) {
 
   const { personalNumber } = decodedToken;
 
-  const [getAllUserCasesError, userCases] = await to(getUserCases(personalNumber));
-  if (getAllUserCasesError) {
-    console.error('getAllUserCasesError', getAllUserCasesError);
-    return response.failure(getAllUserCasesError);
+  const [getUserCaseListError, userCaseList] = await to(getUserCaseList(personalNumber));
+  if (getUserCaseListError) {
+    console.error('getUserCaseListError', getUserCaseListError);
+    return response.failure(getUserCaseListError);
   }
 
-  if (userCases.length === 0) {
+  if (userCaseList.length === 0) {
     return response.failure(new ResourceNotFoundError('No user cases found'));
   }
 
-  const userCasesWithoutPK_SK_GSI1 = userCases.map(item =>
+  const userCaseListWithoutKeys = userCaseList.map(item =>
     objectWithoutProperties(item, ['PK', 'SK', 'GSI1'])
   );
 
   return response.success(200, {
     type: 'getCases',
     attributes: {
-      cases: userCasesWithoutPK_SK_GSI1,
+      cases: userCaseListWithoutKeys,
     },
   });
 }
 
-async function getUserCases(personalNumber) {
-  const [getApplicantCasesError, applicantCasesResult] = await to(
-    getApplicantCases(personalNumber)
+async function getUserCaseList(personalNumber) {
+  const [getUserApplicantCaseListError, applicantCaseListResult] = await to(
+    getUserApplicantCaseList(personalNumber)
   );
-  if (getApplicantCasesError) {
-    console.error('getApplicantCasesError', getApplicantCasesError);
-    throwError(getApplicantCasesError.statusCode, getApplicantCasesError.message);
+  if (getUserApplicantCaseListError) {
+    console.error('getUserApplicantCaseListError', getUserApplicantCaseListError);
+    throwError(getUserApplicantCaseListError.statusCode, getUserApplicantCaseListError.message);
   }
 
-  const [getCoApplicantCasesError, coApplicantCasesResult] = await to(
-    getCoApplicantCases(personalNumber)
+  const [getUserCoApplicantCaseListError, coApplicantCaseListResult] = await to(
+    getUserCoApplicantCaseList(personalNumber)
   );
-  if (getCoApplicantCasesError) {
-    console.error('getCoApplicantCasesError', getCoApplicantCasesError);
-    throwError(getCoApplicantCasesError.statusCode, getCoApplicantCasesError.message);
+  if (getUserCoApplicantCaseListError) {
+    console.error('getUserCoApplicantCaseListError', getUserCoApplicantCaseListError);
+    throwError(getUserCoApplicantCaseListError.statusCode, getUserCoApplicantCaseListError.message);
   }
 
-  const concatAndDeDuplicateCases = (...cases) => [...new Set([].concat(...cases))];
-  return concatAndDeDuplicateCases(applicantCasesResult.Items, coApplicantCasesResult.Items);
+  const concatAndDeDuplicateCaseList = (...cases) => [...new Set([].concat(...cases))];
+  return concatAndDeDuplicateCaseList(
+    applicantCaseListResult.Items,
+    coApplicantCaseListResult.Items
+  );
 }
 
-async function getApplicantCases(personalNumber) {
+async function getUserApplicantCaseList(personalNumber) {
   const PK = `USER#${personalNumber}`;
   const SK = 'CASE#';
 
@@ -72,7 +75,7 @@ async function getApplicantCases(personalNumber) {
   return dynamoDb.call('query', params);
 }
 
-async function getCoApplicantCases(personalNumber) {
+async function getUserCoApplicantCaseList(personalNumber) {
   const GSI1 = `USER#${personalNumber}`;
   const SK = 'CASE#';
 

--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -78,7 +78,7 @@ export async function main(event) {
   const { personalNumber } = decodeToken(event);
   const caseKeys = {
     PK: `USER#${personalNumber}`,
-    SK: `USER#${personalNumber}#CASE#${id}`,
+    SK: `CASE#${id}`,
   };
 
   const params = {

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -2,7 +2,6 @@ service: cases-api
 
 plugins:
   - serverless-bundle
-  - serverless-offline
 
 custom: ${file(../../serverless.common.yml):custom}
 

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -47,7 +47,8 @@ provider:
             - dynamodb:DeleteItem
             - dynamodb:UpdateItem
           Resource:
-            - "Fn::ImportValue": ${self:custom.resourcesStage}-CasesTableArn
+            - !ImportValue ${self:custom.resourcesStage}-CasesTableArn
+            - !ImportValue ${self:custom.resourcesStage}-CasesTableAllIndexArn
 
         - Effect: Allow
           Action:

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -26,13 +26,10 @@ provider:
     resourcesStage: ${self:custom.resourcesStage}
 
   apiGateway:
-    restApiId:
-      "Fn::ImportValue": ${self:custom.stage}-ExtApiGatewayRestApiId
-    restApiRootResourceId:
-      "Fn::ImportValue": ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId
+    restApiId: !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiId
+    restApiRootResourceId: !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId
     restApiResources:
-      cases:
-        "Fn::ImportValue": ${self:custom.stage}-ExtApiGatewayResourceCases
+      cases: !ImportValue ${self:custom.stage}-ExtApiGatewayResourceCases
 
   iam:
     role:
@@ -57,14 +54,14 @@ provider:
             - dynamodb:Query
             - dynamodb:GetItem
           Resource:
-            - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
+            - !ImportValue ${self:custom.resourcesStage}-UsersTableArn
 
         - Effect: Allow
           Action:
             - dynamodb:Query
             - dynamodb:GetItem
           Resource:
-            - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+            - !ImportValue ${self:custom.resourcesStage}-FormsTableArn
 
         - Effect: Allow
           Action:

--- a/services/pdf-ms/helpers/case.ts
+++ b/services/pdf-ms/helpers/case.ts
@@ -25,7 +25,7 @@ export async function getClosedUserCases(
     },
     ExpressionAttributeValues: {
       ':pk': `USER#${personalNumber}`,
-      ':sk': `USER#${personalNumber}`,
+      ':sk': 'CASE#',
       ':statusTypeClosed': 'closed',
     },
   };

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -59,9 +59,9 @@ export async function main(event) {
     return console.error('(Viva-ms) Viva Application WorkflowId not present in response, aborting');
   }
 
-  const casePartitionKey = `USER#${user.personalNumber}`;
+  const PK = `USER#${user.personalNumber}`;
   const [queryCasesError, queryCaseItems] = await to(
-    queryCasesWithWorkflowId(casePartitionKey, vivaPerson.application.workflowid)
+    queryCasesWithWorkflowId(PK, vivaPerson.application.workflowid)
   );
   if (queryCasesError) {
     return console.error('(Viva-ms) DynamoDb query on cases tabel failed', queryCasesError);
@@ -77,7 +77,7 @@ export async function main(event) {
   };
 
   const [putItemError] = await to(
-    putRecurringVivaCase(casePartitionKey, vivaPerson.application.workflowid, period)
+    putRecurringVivaCase(PK, vivaPerson.application.workflowid, period)
   );
   if (putItemError) {
     return console.error('(viva-ms) syncApplicationStatus', putItemError);
@@ -152,10 +152,10 @@ async function putRecurringVivaCase(PK, workflowId, period) {
   const putItemParams = {
     TableName: config.cases.tableName,
     Item: {
-      id,
       PK,
+      SK: `CASE#${id}`,
+      id,
       expirationTime,
-      SK: `${PK}#CASE#${id}`,
       createdAt: timestampNow,
       updatedAt: timestampNow,
       status: initialStatus,


### PR DESCRIPTION
## Feature description
In order for the app to be able to display an application where the user is a co-applicant, the API must have support for retrieving a case where a user is a co-applicant.

## Solution description
A new Global Secondary Index in DynamoDB is created to be able to filter at database level.
When I do a lookup against /cases together with an access token, I want to get back all cases that relate to this user.

## What areas is affected by these changes?.
cases-api/getCaseList
cases-api/getCase

## Is there any exsisting behavior change of other features due to this code change?
SK (Sort key) attribute in Cases-table should not include USER#xxx#CASE#xxx
In this way we can query all cases connected to a user with PK = USER#xxx and SK = begins_with(CASE#)
SK could consist of other access patterns like FORM#, ANSWER# etc

## Are your code strutured in a way so that reviewers can understand it?
Yes

## How to test
Open serverless.yml found in helsingborg-io-sls-resources/services/dynamos/cases/ and delete line 23, 24 and lines 40 to 57

Save!

cd helsingborg-io-sls-resources/services/dynamos/cases/
Run deploy

This will remove old GSI on the table

Checkout dev branch from repo: helsingborg-io-sls-resources

Run deploy

(This is due to a limitation with AWS Cloudformation and how it's creating indexes)

Checkout this PR branch (helsingborg-io-sls-api)
cd helsingborg-io-sls-api/services/cases-api/

Run deploy

Add USER#somepersonalnumber for the attribute GSI1 on a case item in you dynamoDb cases-table

Query /cases/ with somepersonalnumber as access token

Query /cases/ with the personalnumber (as access token) set by PK on the same case item that you put the GSI data above


## Was this feature tested in the following environments?
- [x] Your personal AWS environment
