### PR TITLE
Feat/update cases status

### DIFF
--- a/libs/caseStatuses.js
+++ b/libs/caseStatuses.js
@@ -11,9 +11,9 @@ const statuses = [
       'Du har påbörjat en ansökan. Du kan öppna din ansökan och fortsätta där du slutade.',
   },
   {
-    type: 'active:signed:viva',
+    type: 'active:signed',
     name: 'Signerad',
-    description: 'Ansökan är signerad, ladda upp filer & dokument för att skicka in ansökan.',
+    description: 'Ansökan är signerad',
   },
   {
     type: 'active:submitted',

--- a/services/cases-api/helpers/dynamo.js
+++ b/services/cases-api/helpers/dynamo.js
@@ -1,4 +1,4 @@
-import dynamoDb from '../../../libs';
+import * as dynamoDb from '../../../libs/dynamoDb';
 import config from '../../../config';
 
 export async function getCaseWhereUserIsApplicant(caseId, userPersonalNumber) {

--- a/services/cases-api/helpers/dynamo.js
+++ b/services/cases-api/helpers/dynamo.js
@@ -1,0 +1,19 @@
+import dynamoDb from '../../../libs';
+import config from '../../../config';
+
+export async function getCaseWhereUserIsApplicant(caseId, userPersonalNumber) {
+  const PK = `USER#${userPersonalNumber}`;
+  const SK = `${PK}#CASE#${caseId}`;
+
+  const dynamoDbQueryParams = {
+    TableName: config.cases.tableName,
+    ExpressionAttributeValues: {
+      ':pk': PK,
+      ':sk': SK,
+    },
+    KeyConditionExpression: 'PK = :pk AND SK = :sk',
+    Limit: 1,
+  };
+
+  return dynamoDb.call('query', dynamoDbQueryParams);
+}

--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -7,7 +7,7 @@ const uuid = Joi.string().guid({
 
 const caseProvider = Joi.string().valid(CASE_PROVIDER_VIVA);
 
-const caseAnswers = Joi.array().items(
+const answers = Joi.array().items(
   Joi.object({
     field: Joi.object({
       id: Joi.string().required(),
@@ -17,22 +17,39 @@ const caseAnswers = Joi.array().items(
   })
 );
 
+const encryptedAnswers = Joi.object({
+  encryptedAnswers: Joi.string(),
+});
+
+const formCurrentPosition = Joi.object({
+  index: Joi.number().required(),
+  level: Joi.number().required(),
+  currentMainStep: Joi.number().required(),
+  currentMainStepIndex: Joi.number().required(),
+});
+
+const signature = Joi.object({
+  success: Joi.bool().required(),
+});
+
 const form = Joi.object({
-  answers: caseAnswers.allow(),
-  currentPosition: Joi.object({
-    index: Joi.number().required(),
-    level: Joi.number().required(),
-    currentMainStep: Joi.number().required(),
-    currentMainStepIndex: Joi.number().required(),
-  }).required(),
+  answers: answers.allow(),
+  currentPosition: formCurrentPosition.required(),
 });
 
 const caseValidationSchema = Joi.object({
-  statusType: Joi.string().valid('notStarted').required(),
+  statusType: Joi.string().valid('notStarted'),
   currentFormId: uuid.required(),
   provider: caseProvider.required(),
   details: Joi.object().allow(),
   forms: Joi.object().pattern(/^/, [uuid.required(), form.required()]),
+});
+
+export const updateCaseValidationSchema = Joi.object({
+  currentFormId: uuid.required(),
+  answers: [answers.allow(), encryptedAnswers.allow()],
+  currentPosition: formCurrentPosition.required(),
+  signature: signature.optional(),
 });
 
 export default caseValidationSchema;

--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -29,7 +29,7 @@ export async function main(event) {
     abortEarly: false,
   });
   if (error) {
-    response.failure(new BadRequestError(error.message.replace(/"/g, "'")));
+    return response.failure(new BadRequestError(error.message.replace(/"/g, "'")));
   }
 
   const {

--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -32,14 +32,7 @@ export async function main(event) {
     return response.failure(new BadRequestError(error.message.replace(/"/g, "'")));
   }
 
-  const {
-    provider,
-    details,
-    currentFormId,
-    currentPosition,
-    answers,
-    signature,
-  } = validatedEventBody;
+  const { currentFormId, currentPosition, answers, signature } = validatedEventBody;
 
   const [getCaseError] = await to(getCaseWhereUserIsApplicant(id, personalNumber));
   if (getCaseError) {
@@ -55,20 +48,10 @@ export async function main(event) {
   const ExpressionAttributeNames = {};
   const ExpressionAttributeValues = { ':newUpdatedAt': Date.now() };
 
-  if (provider) {
-    UpdateExpression.push('provider = :newProvider');
-    ExpressionAttributeValues[':newProvider'] = provider;
-  }
-
   if (newCaseStatus) {
     UpdateExpression.push('#status = :newStatus');
     ExpressionAttributeNames['#status'] = 'status';
     ExpressionAttributeValues[':newStatus'] = newCaseStatus;
-  }
-
-  if (details) {
-    UpdateExpression.push('details = :newDetails');
-    ExpressionAttributeValues[':newDetails'] = details;
   }
 
   if (currentFormId) {

--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -25,9 +25,12 @@ export async function main(event) {
     return response.failure(new BadRequestError('Missing required path parameter "id"'));
   }
 
-  const { error, validatedEventBody } = updateCaseValidationSchema.validate(requestJsonBody, {
-    abortEarly: false,
-  });
+  const { error, value: validatedEventBody } = updateCaseValidationSchema.validate(
+    requestJsonBody,
+    {
+      abortEarly: false,
+    }
+  );
   if (error) {
     return response.failure(new BadRequestError(error.message.replace(/"/g, "'")));
   }


### PR DESCRIPTION
## Explain the changes you’ve made

Removed support for setting the status on a case from request attributes, the status is now instead dynamically set based on attributes in the request data.

## Explain why these changes are made
Added new status for case active:signature:completed
Checking if the case exists before trying to preform updates.
Added support for conditional retrieving of the case status based on answers and signatures attributes in the json payload.
Updating the case status if there is any new status to be retrieved.

## Explain your solution

Earlier we allowed the setting of a case status by passing a value on the attribute statusType
in the json payload, this behavior is now deprecated. 

Now instead the lambda looks on the data in the json payload to figure out if the case status should be updated and what that status is. 

The lambda can currently set three statuses on a case active:ongoing, active:signature:completed,
active:submitted based on the answers attribute and a new attribute called signature from the json
payload.

Statuses are set when a certain condition is true:
active:ongoing is set when answers in the payload are encrypted.
active:signature:completed is set when the answers in the payload are encrypted and a the signature is completed 
active:submitted is set when a answers are decrypted and the signature is completed.

## How to test the changes?

Concrete example:
1. Checkout this branch.
2. Recommended to use your own AWS sandbox environment.
3. Deploy the cases service.
4. Add/Create an initial case in your DynamoDB
5. Send put request towards /cases/{id} (id should be the id from your new case)

ongoing status
```JSON 
{
  "currentFormId": REPLACE_WITH_A_CURRENT_FORM_ID,
   "currentPosition": {
		"index": 0,
		"level": 0,
		"currentMainStep": 0,
		"currentMainStepIndex": 0
   },
   "answers": { "encryptedAnswers": "an_encrypted_string"},
   "signature": { "success": false}
}
```

signature completed status
```JSON 
{
  "currentFormId": REPLACE_WITH_A_CURRENT_FORM_ID,
   "currentPosition": {
		"index": 0,
		"level": 0,
		"currentMainStep": 0,
		"currentMainStepIndex": 0
   },
   "answers": { "encryptedAnswers": "an_encrypted_string"},
   "signature": { "success": true}
}
```

submitted status
```JSON 
{
   "currentFormId": REPLACE_WITH_A_CURRENT_FORM_ID,
   "currentPosition": {
		"index": 0,
		"level": 0,
		"currentMainStep": 0,
		"currentMainStepIndex": 0
   },
   "answers": [{...}, {...}],
   "signature": { "success": true}
}
```

## Was this feature tested in the following environments?
- [X] AWS Sandbox environment.

## Anything else
BREAKING CHANGE: All clients that uses the /cases/{id} with the PUT method will need to update their
requests in order to comply with these new changes.


