### PR TITLE
Feat/append encryption attributes

### DIFF
--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -21,7 +21,15 @@ const encryptedAnswers = Joi.object({
   encryptedAnswers: Joi.string(),
 });
 
-const encryption = Joi.object({ type: Joi.string() });
+const encryption = Joi.object({
+  type: Joi.string().required(),
+  symmetricKeyName: Joi.string(),
+  primes: Joi.object({
+    P: Joi.number(),
+    G: Joi.number(),
+  }),
+  publicKeys: Joi.object().pattern(/^/, [Joi.string()]),
+});
 
 const formCurrentPosition = Joi.object({
   index: Joi.number().required(),

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -300,7 +300,7 @@ async function getUser(PK) {
 }
 
 async function getFormTemplates(formIds) {
-  const [getError, forms] = await to(
+  const [getError, rawForms] = await to(
     Promise.all(
       formIds.map(formId => {
         const formGetParams = {
@@ -319,13 +319,17 @@ async function getFormTemplates(formIds) {
     throw getError;
   }
 
-  return forms.reduce(
-    (templates, form) => ({
-      ...templates,
-      [form.Item.id]: form.Item,
+  const forms = rawForms.map(rawForm => rawForm.Item);
+
+  const formsMap = forms.reduce(
+    (formsMap, form) => ({
+      ...formsMap,
+      [form.id]: form,
     }),
     {}
   );
+
+  return formsMap;
 }
 
 async function getLastUpdatedCase(PK, provider) {

--- a/services/viva-ms/lambdas/createVivaCase.js
+++ b/services/viva-ms/lambdas/createVivaCase.js
@@ -178,6 +178,13 @@ async function putRecurringVivaCase(vivaPerson) {
   const casePersonCoApplicant = getUserByRole(casePersonList, 'coApplicant');
   if (casePersonCoApplicant) {
     caseItemPutParams.Item['GSI1'] = `USER#${casePersonCoApplicant.personalNumber}`;
+
+    const mainApplicantPno = stripNonNumericalCharacters(String(vivaPerson.case.client.pnumber));
+    appendEncryptionAttributes(
+      initialFormAttributes,
+      mainApplicantPno,
+      casePersonCoApplicant.personalNumber
+    );
   }
 
   casePersonList = casePersonList.map(person => {
@@ -324,4 +331,13 @@ async function getLastUpdatedCase(PK, provider) {
   const sortedCases = dbResponse.Items.sort((a, b) => b.updatedAt - a.updatedAt);
 
   return sortedCases?.[0] || {};
+}
+
+function appendEncryptionAttributes(formAttributes, mainApplicantPno, coApplicantPno) {
+  formAttributes.encryption.symmetricKeyName = `${mainApplicantPno}:${coApplicantPno}`;
+  formAttributes.encryption.primes = { P: 43, G: 10 };
+  formAttributes.encryption.publicKeys = {
+    [mainApplicantPno]: '',
+    [coApplicantPno]: '',
+  };
 }


### PR DESCRIPTION
## Explain the changes you’ve made

Appending symmetric key attributes when creating a VIVA case with co applicant.

## Explain why these changes are made

Symmetric key attributes must be present when setting up a Diffie-Hellman shared key between two or more clients:
For EKB, we have encrypted answers that are shared so that the co applicant can approve and sign the case.

## Explain your solution

Appending encryption values to a case if a co applicant is found.
Following values shall be appended when co applicant (with pno 198310011906) present (main applicant pno 196912191118):
```json
encryption: {
      "type": "decrypted",
      "symmetricKeyName": "196912191118:198310011906",
      "primes": {
        "P": 43,
        "G": 10,
      },
      "publicKeys": {
        "196912191118": "",
        "198310011906": "",
      },
    },
```

## How to test the changes?

Concrete example:

1. Checkout this branch.
2. Deploy viva-ms service in your own AWS sandbox environment.
3. In app MH, log in with a user that has a co applicant (ex. user Ali Al-Jabi). Remove any present cases, in AWS dynamoDB cases, before logging in with user.
4. In AWS dynamoDB cases, validate forms[some_id] -> encryption keys and values for the newly created case.