### PR TITLE
Fix/bankid collect user agent check

### DIFF
--- a/services/bankid-api/lambdas/collect.js
+++ b/services/bankid-api/lambdas/collect.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { throwError } from '@helsingborg-stad/npm-api-error-handling';
 import to from 'await-to-js';
 import config from '../../../config';
@@ -17,7 +18,6 @@ export const main = async event => {
   const { orderRef } = JSON.parse(body);
   const bankidSSMParams = await SSMParams;
 
-  // eslint-disable-next-line no-console
   console.info('🚀 ~ file: collect.js ~ line 21 ~ headers -> User-Agent', headers['User-Agent']);
 
   const payload = { orderRef };
@@ -66,7 +66,6 @@ export const main = async event => {
     };
   }
 
-  // eslint-disable-next-line no-console
   console.info('🚀 ~ file: collect.js ~ line 70 ~ responseAttributes', responseAttributes);
 
   return response.success(200, {
@@ -85,11 +84,6 @@ function isUserAgentMittHelsingborgApp(headers) {
   return userAgent.includes(searchElement);
 }
 
-/**
- * Function for generating a authorization code, to be used for obtaining a access token.
- * @param {object} payload a object with only one level of depth.
- * @returns JWT (Json Web Token)
- */
 async function generateAuthorizationCode(personalNumber) {
   const [authorizationCodeSecretError, auhtorizationCodeSecret] = await to(
     secrets.get(

--- a/services/bankid-api/lambdas/collect.js
+++ b/services/bankid-api/lambdas/collect.js
@@ -80,8 +80,8 @@ function isBankidCollectStatusComplete(responseData) {
 
 function isUserAgentMittHelsingborgApp(headers) {
   const { ['User-Agent']: userAgent } = headers;
-  const searchElement = 'MittHelsingborg';
-  return userAgent.includes(searchElement);
+  const searchElementRegex = /^Mitt\s?Helsingborg$/;
+  return searchElementRegex.test(userAgent);
 }
 
 async function generateAuthorizationCode(personalNumber) {

--- a/services/bankid-api/lambdas/collect.js
+++ b/services/bankid-api/lambdas/collect.js
@@ -17,6 +17,9 @@ export const main = async event => {
   const { orderRef } = JSON.parse(body);
   const bankidSSMParams = await SSMParams;
 
+  // eslint-disable-next-line no-console
+  console.info('🚀 ~ file: collect.js ~ line 21 ~ headers -> User-Agent', headers['User-Agent']);
+
   const payload = { orderRef };
 
   const [bankIdCollectRequestError, bankIdCollectResponse] = await to(
@@ -62,6 +65,9 @@ export const main = async event => {
       ...responseAttributes,
     };
   }
+
+  // eslint-disable-next-line no-console
+  console.info('🚀 ~ file: collect.js ~ line 70 ~ responseAttributes', responseAttributes);
 
   return response.success(200, {
     type: 'bankIdCollect',

--- a/services/bankid-api/serverless.yml
+++ b/services/bankid-api/serverless.yml
@@ -2,7 +2,8 @@ service: bankid-api
 
 plugins:
   - serverless-bundle
-  - serverless-offline
+
+projectDir: ../../
 
 custom: ${file(../../serverless.common.yml):custom}
 
@@ -17,7 +18,6 @@ provider:
   region: eu-north-1
   endpointType: regional
   tracing:
-    apiGateway: true
     lambda: true
   apiGateway:
     restApiId:


### PR DESCRIPTION
## Explain the changes you’ve made
The BankID collect lambda have a new check in place to verify if the incoming request is from our Mitt Helsingborg Application (iOS/Android). 

If the this requirement is fulfilled we (a) send a bankid.collect event to the AWS event-bridge and (b) pass a new created authorization-code in the json response back to the client.

If the requirement is not full-filled we only return BankID related information to the client.

## Explain your solution

The solution for verifying if a request comes from our trusted Mitt Helsingborg app is to check the User-Agent header that is passed in the request towards the bankid/collect endpoint. If the User-Agent string contains `MittHelsingborg` we fire the event and return an authorization-code alongside with bankid related information. 
## How to test the changes?

In order to test these changes you need to do the following:

(1) Deploy the BankID service in your sandbox. 
(2) Make sure you have a user that is setup with bankid on your computer. (
3) Start a bankid auth process by sending a request towards the bankid/auth endpoint and copy the orderRef in the response. 
(4) Send a request towards the bankid/collect endpoint with the previous copied orderRef to check that bankid order is pending. 
(5) Verify the pending order request with bankid on your computer. 
(6) Check the response from bankid/collect it should not contain an authorizationCode attribute.
(7) Now repeat step 3 to 5 but on step 4 pass a User-Agent header that contains MittHelsingborg.
(8) Check the response and it should contain an authorizationCode attribute.
(9) Check the logs in your aws console to see if the navet-poll lambda have been triggered. (Should only happen if the User-Agen header is passed and contains MittHelsingborg)




## Was this feature tested in the following environments?
- [X] AWS personal sandbox.
- [X] AWS personal sandbox + Mitt Helsingborg iOS application
- [] AWS personal sandbox + Mitt Helsingborg Android application

## Additional Notes
This is a patch to avoid creation of users when third party clients uses our bankid service. This is however not a solid solution and needs an overhaul of the auth in conjunction with bankid should be made. The bankid service and suth service are not loose-coupled at the moment, and they really should be in the future.