### PR TITLE
feat: allow case encryption public key values to be null

### DIFF
--- a/services/cases-api/helpers/schema.js
+++ b/services/cases-api/helpers/schema.js
@@ -28,7 +28,7 @@ const encryption = Joi.object({
     P: Joi.number(),
     G: Joi.number(),
   }),
-  publicKeys: Joi.object().pattern(/^/, [Joi.string()]),
+  publicKeys: Joi.object().pattern(/^/, [Joi.string(), null]),
 });
 
 const formCurrentPosition = Joi.object({


### PR DESCRIPTION
## Explain the changes you’ve made

Allowed values to be `null` for case `encryption.publicKeys`.

## Explain why these changes are made

Key values are initially null when created by `createVivaCase` (when creating a case with a co-applicant). Subsequent calls to `updateCase` however fails if key values are (re)supplied with the `null` value. This happens when an applicant or co-applicant attempts to update only their own public key value, sending something like:

```json
"publicKeys": {
    "199901011234": "20",
    "200001011234": null
}
```

where "20" is their (updated) own public key value. Currently, `updateCase` fails with `"'encryption.publicKeys.200001011234' must be a string"`.

## Explain your solution

Changed Joi validation scheme to allow `null` as a value type for public keys.

## How to test the changes?

1) Checkout this branch and deploy to your sandbox
2) Prepare a case with co-applicant
3) Make a put request to `/cases/<case id>` with a public key object where one value is null
4) Verify that the case is now updated with the new public key values