### PR TITLE
feat: add parameter store implementation of bookables service

### DIFF
--- a/config.js
+++ b/config.js
@@ -43,6 +43,9 @@ const stageConfigs = {
     search: {
       envsKeyName: '/searchEnvs/dev',
     },
+    bookables: {
+      envsKeyName: '/bookablesEnvs/dev',
+    },
     vada: {
       envsKeyName: '/vadaEnvs/dev',
     },
@@ -92,6 +95,9 @@ const stageConfigs = {
     },
     search: {
       envsKeyName: '/searchEnvs/test',
+    },
+    bookables: {
+      envsKeyName: '/bookablesEnvs/test',
     },
     vada: {
       envsKeyName: '/vadaEnvs/test',
@@ -143,6 +149,9 @@ const stageConfigs = {
     search: {
       envsKeyName: '/searchEnvs/stage',
     },
+    bookables: {
+      envsKeyName: '/bookablesEnvs/stage',
+    },
     vada: {
       envsKeyName: '/vadaEnvs/stage',
     },
@@ -193,6 +202,9 @@ const stageConfigs = {
     search: {
       envsKeyName: '/searchEnvs/prod',
     },
+    bookables: {
+      envsKeyName: '/bookablesEnvs/prod',
+    },
     vada: {
       envsKeyName: '/vadaEnvs/prod',
     },
@@ -242,6 +254,9 @@ const stageConfigs = {
     },
     search: {
       envsKeyName: '/searchEnvs/release',
+    },
+    bookables: {
+      envsKeyName: '/bookablesEnvs/release',
     },
     vada: {
       envsKeyName: '/vadaEnvs/release',

--- a/services/bookables-api/README.md
+++ b/services/bookables-api/README.md
@@ -1,0 +1,99 @@
+# HELSINGBORG IO SLS BOOKABLES SERVICE
+
+## Purpose
+
+The Bookables Service's purpose is to provide the app with data related to services that can be booked at Helsingborg Stad.
+
+## Description
+
+The Bookables Service is an API that returns information about the bookable services at Helsingborg Stad. Currently it retrieves the data from the parameter store, for ease of deployment. In the future this could be developed further into a platform with its own dynamo.
+
+## Getting started
+
+1. Read the global requierments for this repo, can be found [here](https://github.com/helsingborg-stad/helsingborg-io-sls-api/blob/dev/README.md)
+
+### AWS API GATEWAY
+
+A running instance of an API GATEWAY on AWS that includes a gateway resource named /search. You can find and deploy this in our [resource](https://github.com/helsingborg-stad/helsingborg-io-sls-resources/tree/dev/services/gateway/resources/search) repository.
+
+### AWS PARAMETERSTORE (OPTIONAL)
+
+A setup of search AWS paramterstore on aws. This can be created from the resource api. You can find and deploy this in our [resource](https://github.com/helsingborg-stad/helsingborg-io-sls-resources/tree/dev/services/parameterStore) repository.
+
+### Installation
+
+```bash
+$ npm install
+```
+
+### Run Local
+
+```bash
+$ sls offline
+```
+
+When you deploy the service, serverless will output the generated url in the terminal that the service can be accessed from.
+
+### Deploy and Run on AWS
+
+Deploy command:
+
+```bash
+$ sls deploy -v
+```
+
+When you deploy the service, serverless will output the generated url in the terminal that the service can be accessed from.
+
+### Tear down service
+
+Teardown command:
+
+```bash
+$ sls remove
+```
+
+When you tear down the service, serverless will remove all resources created in the AWS console, including emptying the `deploymentBucket`.
+
+### Testing (Jest)
+
+Run test command:
+
+```bash
+$ npm run test
+```
+
+Run test command with [options](https://jestjs.io/docs/cli#options):
+
+```bash
+$ npm run test -- --[option_1] --[option_2]
+```
+
+## API
+
+### GET BOOKABLES
+
+#### Request Type
+
+`GET`
+
+#### Endpoint
+
+`/bookables`
+
+#### Expected JSON Response
+
+```json
+{
+    "jsonapi": {
+        "version": "1.0"
+    },
+    "data": [
+      {
+        "name": "Rådgivning",
+        "sharedMailbox": "mh.support@helsingborg.se",
+        "address": "Drottninggatan 2, Helsingborg",
+        "formId": "xxxx"
+      }
+    ]
+}
+```

--- a/services/bookables-api/README.md
+++ b/services/bookables-api/README.md
@@ -6,11 +6,11 @@ The Bookables Service's purpose is to provide the app with data related to servi
 
 ## Description
 
-The Bookables Service is an API that returns information about the bookable services at Helsingborg Stad. Currently it retrieves the data from the parameter store, for ease of deployment. In the future this could be developed further into a platform with its own dynamo.
+The Bookables Service is an API that returns information about the bookable services at Helsingborg Stad. It retrieves the data from the parameter store.
 
 ## Getting started
 
-1. Read the global requierments for this repo, can be found [here](https://github.com/helsingborg-stad/helsingborg-io-sls-api/blob/dev/README.md)
+1. Read the global requirements for this repo, can be found [here](https://github.com/helsingborg-stad/helsingborg-io-sls-api/blob/dev/README.md)
 
 ### AWS API GATEWAY
 
@@ -31,15 +31,12 @@ $ npm install
 ```bash
 $ sls offline
 ```
-
-When you deploy the service, serverless will output the generated url in the terminal that the service can be accessed from.
-
 ### Deploy and Run on AWS
 
 Deploy command:
 
 ```bash
-$ sls deploy -v
+$ sls deploy
 ```
 
 When you deploy the service, serverless will output the generated url in the terminal that the service can be accessed from.

--- a/services/bookables-api/babel.config.js
+++ b/services/bookables-api/babel.config.js
@@ -1,0 +1,5 @@
+const babelBase = require('../../babel-base.config');
+
+module.exports = {
+  ...babelBase,
+};

--- a/services/bookables-api/helpers/bookables.js
+++ b/services/bookables-api/helpers/bookables.js
@@ -1,0 +1,21 @@
+import { throwError } from '@helsingborg-stad/npm-api-error-handling';
+import to from 'await-to-js';
+
+import params from '../../../libs/params';
+import config from '../../../config';
+
+async function getBookables() {
+  const { bookables } = await getSsmParameters();
+  return bookables;
+}
+
+async function getSsmParameters() {
+  const [error, response] = await to(params.read(config.bookables.envsKeyName));
+  if (error) {
+    throwError(500);
+  }
+
+  return response;
+}
+
+export { getBookables };

--- a/services/bookables-api/lambdas/getBookables.js
+++ b/services/bookables-api/lambdas/getBookables.js
@@ -1,0 +1,14 @@
+import to from 'await-to-js';
+
+import * as response from '../../../libs/response';
+
+import { getBookables } from '../helpers/bookables';
+
+export async function main() {
+  const [ssmError, bookables] = await to(getBookables());
+  if (ssmError) {
+    return response.failure(ssmError);
+  }
+
+  return response.success(200, bookables);
+}

--- a/services/bookables-api/package.json
+++ b/services/bookables-api/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "test": "node ../../node_modules/.bin/jest"
   },
-  "keywords": [],
   "author": "Helsingborg Stad",
   "license": "MIT"
 }

--- a/services/bookables-api/package.json
+++ b/services/bookables-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "bookables-api",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node ../../node_modules/.bin/jest"
+  },
+  "keywords": [],
+  "author": "Helsingborg Stad",
+  "license": "MIT"
+}

--- a/services/bookables-api/serverless.yml
+++ b/services/bookables-api/serverless.yml
@@ -1,0 +1,53 @@
+service: bookables-api
+
+plugins:
+  - serverless-bundle
+  - serverless-add-api-key
+
+projectDir: ../../
+
+custom: ${file(../../serverless.common.yml):custom}
+
+package:
+  individually: true
+
+provider:
+  lambdaHashingVersion: 20201221
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-north-1
+  endpointType: regional
+  tracing:
+    lambda: true
+  apiGateway:
+    restApiId:
+      !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiId
+    restApiRootResourceId:
+      !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId
+    restApiResources:
+      bookables:
+        !ImportValue ${self:custom.stage}-ExtApiGatewayResourceBookables
+
+  environment:
+    stage: ${self:custom.stage}
+    resourcesStage: ${self:custom.resourcesStage}
+
+  iam:
+    role:
+      statements:
+        - Effect: Allow
+          Action:
+            - ssm:GetParameter
+          Resource:
+            - !Sub arn:aws:ssm:${self:provider.region}:${AWS::AccountId}:parameter/bookablesEnvs/${self:provider.stage}
+
+functions:
+  getBookables:
+    handler: lambdas/getBookables.main
+    events:
+      - http:
+          path: bookables
+          method: get
+          private: true
+          cors: true


### PR DESCRIPTION
## What was solved

Added a new service (bookables-api) for listing bookable services for Mitt Helsingborg. The data is retrieved from the parameter store for now. Depends on https://github.com/helsingborg-stad/helsingborg-io-sls-resources/pull/75 being approved to avoid pipeline trouble.

## How was it solved

It was solved by creating a new API that retrieves the relevant information from the parameter store.

## Why was it solved in this way

Optimally we would create a platform with a UI and perhaps a dynamo for storing the bookable services, but due to time constraints (and the relative immutability of the bookable services offered by the municipality) we opted for a simple UI-less parameter store solution for now.
Even though the code structure might seem somewhat redundant, it was written to be consistent with the rest of the repository and open for further development (perhaps to the aforementioned platform).

## How was it tested

It was tested by deploying the stack to my sandbox and making successful requests against API Gateway from the AWS UI, as well as from within the application in a demo.