### PR TITLE
Feat/add notes section to template

### DIFF
--- a/services/html-pdf-ms/templates/ekb-recurring.hbs
+++ b/services/html-pdf-ms/templates/ekb-recurring.hbs
@@ -83,6 +83,16 @@
       </div>
     </header>
 
+    <section>
+        <table>
+            {{#each notes}}
+                <tr>
+                    <td>{{this.title}}</td>
+                    <td>{{this.text}}</td>
+                </tr>
+            {{/each}}
+        </table>
+    </section>
     {{!-- Sections for each person --}}
     {{#each persons}}
     <section>

--- a/services/viva-ms/helpers/createRecurringCaseTemplateData.js
+++ b/services/viva-ms/helpers/createRecurringCaseTemplateData.js
@@ -59,6 +59,20 @@ export function createPersonsObject(persons, answers) {
   return applicantPersons;
 }
 
+function createNotesObject(answers) {
+  const notes = [];
+  const filteredAnswers = formHelpers.filterByFieldIdIncludes(answers, 'otherMessage');
+  if (filteredAnswers.length) {
+    const [noteAnswer] = filteredAnswers;
+    const note = {
+      title: 'Meddelande från sökande',
+      text: noteAnswer.value,
+    };
+    notes.push(note);
+  }
+  return notes;
+}
+
 export function createHousingInfoObject(answers) {
   const filteredAnswers = formHelpers.filterByFieldIdIncludes(answers, 'housingInfo');
 
@@ -148,8 +162,10 @@ export default function createRecurringCaseTemplateData(caseItem, recurringFormI
   const persons = createPersonsObject(caseItem.persons, recurringform.answers);
   const housing = createHousingInfoObject(recurringform.answers);
   const economics = createEconomicsObject(recurringform.answers);
+  const notes = createNotesObject(recurringform.answers);
 
   return {
+    notes,
     period,
     persons,
     housing,


### PR DESCRIPTION
## Explain the changes you’ve made
Added a new notes section in the pdf to display informal messages from applicant

## Explain why these changes are made
These changes makes it possible for the applicant to inform an administrator about things that are not nessecary to submit in an applicant. This information needs to be in the pdf so that an administrator can be notified and correctly asses the application.

## Explain your solution
The soultion was create a new attribute in the template-data called notes. The notes attribute is an array of objects that has the follwing shape.
```JS
{
title: 'Some title to display',
text: 'The message submitted by the applicant'
}
```
In order to populate this object with information from the form answers submitted i filtered out the answer based on it's id `otherMessage` and then inserted the value as the value of the text attribute in the note object.

The final result for the notes attribute in the template-data should look like this for know.

```JS
{
  ...,
  notes: [
    {
      title: 'Some title to display',
      text: 'The message submitted by the applicant'
    }
  ],
  ...
}
```

This data is further used in the ekb-recurring.hbs template to render the content when we generate html in the html-pdf-ms service. So the template has been updated to support this. This is how the section for notes looks.

```HTML
...
<section>
        <table>
            {{#each notes}}
                <tr>
                    <td>{{this.title}}</td>
                    <td>{{this.text}}</td>
                </tr>
            {{/each}}
        </table>
    </section>
...
```

## How to test the changes?

1. Checkout this branch
2. Deploy the resources and services that are needed in order for the pdf flow to work.
3. Upload the new template `ekb-recurring.hbs` to the templates folder in your pdf-storage bucket 
4. Submit form answers that includes a message from the applicant from the app or via the api, make sure it's decrypted and has the status set to active:submitted.

## Was this feature tested in the following environments?
- [X] Personal AWS Sandbox
