### PR TITLE
Fix/format date for economics post

### DIFF
--- a/services/viva-ms/helpers/createRecurringCaseTemplateData.js
+++ b/services/viva-ms/helpers/createRecurringCaseTemplateData.js
@@ -1,5 +1,5 @@
 import { TAG_NAME, VIVA_POST_TYPE_COLLECTION, PERSON_ROLE } from './constans';
-import formatPeriodDates from './formatPeriodDates';
+import formatPeriodDates, { formatTimestampToDate } from './formatPeriodDates';
 import formHelpers from './formHelpers';
 
 function mapApplicant(person, answers) {
@@ -110,7 +110,7 @@ export function createEconomicsObject(answers) {
       }
 
       if (tags.includes(TAG_NAME.date)) {
-        summaryItem.date = answer.value;
+        summaryItem.date = formatTimestampToDate(answer.value);
       }
 
       const vivaPostType = tags.reduce((type, tag) => {

--- a/services/viva-ms/helpers/formatPeriodDates.js
+++ b/services/viva-ms/helpers/formatPeriodDates.js
@@ -1,4 +1,4 @@
-function formatTimestampToDate(timestamp) {
+export function formatTimestampToDate(timestamp) {
   const [date] = new Date(timestamp).toISOString().split('T');
   return date;
 }


### PR DESCRIPTION
The format of dates that are passed to the template have been changed from timestamp to a string with YYYY-MM-DD format.