### PR TITLE
fix(ekb-recurring.hbs): updated template to render sections of data correctly

### DIFF
--- a/services/html-pdf-ms/templates/ekb-recurring.hbs
+++ b/services/html-pdf-ms/templates/ekb-recurring.hbs
@@ -71,25 +71,19 @@
             <tr>
                 <td>Adress</td>
                 <td>
-                    {{#if postalAdress}}
                     {{postalAdress}}
-                    {{/if}}
                 </td>
             </tr>
             <tr>
                 <td>Postnummer</td>
                 <td>
-                    {{#if postalCode}}
                     {{postalCode}}
-                    {{/if}}
                 </td>
             </tr>
             <tr>
                 <td>Ort</td>
                 <td>
-                    {{#if postalAdress}}
                     {{postalAdress}}
-                    {{/if}}
                 </td>
             </tr>
             <tr>
@@ -127,9 +121,7 @@
             <tr>
                 <td>Antal boende i bostaden</td>
                 <td>
-                    {{#if numberPeopleLiving}}
-                    {{numberPeopleLiving}}
-                    {{/if}}
+                    {{numberpeopleLiving}}
                 </td>
             </tr>
         </table>
@@ -149,15 +141,16 @@
                 {{#each economics.incomes}}
 
                 {{#if (and
-                (eq this.belongsTo 'APPLICANT')
-                (eq this.type 'incomes'))}}
+                (eq this.belongsTo 'APPLICANT'))}}
                 <tr>
                     <td>
                         {{this.title}} {{this.description}}
                     </td>
                     <td>
                         <span>
-                            {{this.value}}
+                            {{#if this.value}}
+                                {{this.value}} {{this.currency}}
+                            {{/if}}
                         </span>
                         {{#if this.date}}
                         <span>
@@ -178,8 +171,7 @@
                 {{#each economics.incomes}}
 
                 {{#if (and
-                (eq this.belongsTo 'COAPPLICANT')
-                (eq this.type 'incomes'))
+                (eq this.belongsTo 'COAPPLICANT'))
                 }}
                 <tr>
                     <td>
@@ -187,7 +179,9 @@
                     </td>
                     <td>
                         <span>
-                            {{this.value}}
+                            {{#if this.value}}
+                                {{this.value}} {{this.currency}}
+                            {{/if}}
                         </span>
                         {{#if this.date}}
                         <span>
@@ -208,8 +202,7 @@
                 {{#each economics.incomes}}
 
                 {{#if (and
-                (eq this.belongsTo 'HOUSING')
-                (eq this.type 'incomes'))
+                (eq this.belongsTo 'HOUSING'))
                 }}
                 <tr>
                     <td>
@@ -248,8 +241,7 @@
                 {{#each economics.expenses}}
 
                 {{#if (and
-                (eq this.belongsTo 'APPLICANT')
-                (eq this.type 'expenses'))}}
+                (eq this.belongsTo 'APPLICANT'))}}
                 <tr>
                     <td>
                         {{this.title}} {{this.description}}
@@ -276,8 +268,7 @@
                 {{#each economics.expenses}}
 
                 {{#if (and
-                (eq this.belongsTo 'COAPPLICANT')
-                (eq this.type 'expenses'))
+                (eq this.belongsTo 'COAPPLICANT'))
                 }}
                 <tr>
                     <td>
@@ -306,8 +297,7 @@
                 {{#each economics.expenses}}
 
                 {{#if (and
-                (eq this.belongsTo 'HOUSING')
-                (eq this.type 'expenses'))
+                (eq this.belongsTo 'HOUSING'))
                 }}
                 <tr>
                     <td>


### PR DESCRIPTION
## Explain the changes you’ve made
Making rendering of expenses and incomes sections work and compile to html correctly from the template data.

## Explain why these changes are made
The sections for expenses and incomes did not render as expected. 

## Explain your solution
Fixed the if statements for rendering of expenses and incomes so that they all are compiled to html in the end.

## How to test the changes?

1. Checkout this branch
2. Deploy the resources and services that are needed in order for the pdf flow to work.
3. Upload the new template ekb-recurring.hbs to the templates folder in your pdf-storage bucket
4. Submit form answers that includes a expenses and incomes for both applicant and co-applicant from the app or via the api, make sure it's decrypted and has the status set to active:submitted.

## Was this feature tested in the following environments?
- [X] Personal AWS Sandbox.
