### PR TITLE
Feat/pdf add assets section

### DIFF
--- a/services/html-pdf-ms/templates/ekb-recurring.hbs
+++ b/services/html-pdf-ms/templates/ekb-recurring.hbs
@@ -414,6 +414,21 @@
 
     </section>
 
+    {{!-- Section for assets --}}
+    <section>
+        <h1>Tillgångar</h1>
+        <table>
+            {{#each assets}}
+                {{#if this.value}}
+                    <tr>
+                        <td>{{this.title}}</td>
+                        <td>{{this.value}} {{this.currency}}</td>
+                    </tr>
+                {{/if}}
+            {{/each}}
+        </table>
+    </section>
+
 
 </body>
 

--- a/services/viva-ms/helpers/createRecurringCaseTemplateData.js
+++ b/services/viva-ms/helpers/createRecurringCaseTemplateData.js
@@ -128,6 +128,56 @@ function createHousingExpenses(answers) {
 
   return expenses;
 }
+function createAssetsObject(answers) {
+  const commonFilterTags = ['amount', 'assets'];
+  const categories = [
+    {
+      title: 'Bil',
+      filterTags: ['bil', ...commonFilterTags],
+      value: '',
+    },
+    {
+      title: 'Motorcykel',
+      filterTags: ['motorcykel', ...commonFilterTags],
+      value: '',
+    },
+    {
+      title: 'Hus',
+      filterTags: ['hus', ...commonFilterTags],
+      value: '',
+    },
+    {
+      title: 'Bostadsrätt',
+      filterTags: ['lagenhet', ...commonFilterTags],
+      value: '',
+    },
+    {
+      title: 'Övriga fordon',
+      filterTags: ['other', 'vehicle', ...commonFilterTags],
+      value: '',
+    },
+    {
+      title: 'Övriga tillgångar',
+      filterTags: ['other', 'asset', ...commonFilterTags],
+      value: '',
+    },
+  ];
+
+  const assets = categories.map(category => {
+    const [answer] = formHelpers.filterByTags(answers, category.filterTags);
+    if (answer) {
+      return {
+        type: 'asset',
+        title: category.title,
+        value: answer.value,
+        currency: 'kr',
+      };
+    }
+    return undefined;
+  });
+
+  return assets;
+}
 
 export function createEconomicsObject(answers) {
   const categories = ['expenses', 'incomes'];
@@ -213,9 +263,11 @@ export default function createRecurringCaseTemplateData(caseItem, recurringFormI
   const housing = createHousingInfoObject(recurringform.answers);
   const economics = createEconomicsObject(recurringform.answers);
   const notes = createNotesObject(recurringform.answers);
+  const assets = createAssetsObject(recurringform.answers);
 
   return {
     notes,
+    assets,
     period,
     persons,
     housing,


### PR DESCRIPTION
## Feature description
The changes made in this PR adds a new attribute (assets) to the recurring case template-data. The assets attribute is the further used in the ekb-recurring.hbs template in order to show assets in the html output.

## Solution description
In order to add this new assets attribute to the template-data we need to extract the assets information from a submitted case's form answers. This data conversion is done by filtering out answers by tags and then converting the answers to objects and saved to an array that can be iterated over in a template to render assets.

## What areas is affected by these changes?.
changes have been made to the following services `viva-ms` and `html-pdf-ms`

## Is there any existing behaviour change of other features due to this code change?
No

## Covered unit tests cases / E2E test cases?
No

## Are your code structured in a way so that reviewers can understand it?
Yes, would like to mention that there is an increase in redundancy for new functions that is added to the helper file createRecurringCaseTemplate.js

So there will be a continues work to refactor the changes that is added now due to time limitation. 

## Was this feature tested in the following environments?
- [x] Your personal AWS sandbox environment.
