### PR TITLE
feat: add lambda for searching bookings by their reference code

### DIFF
--- a/services/booking-api/README.md
+++ b/services/booking-api/README.md
@@ -202,3 +202,55 @@ $ npm run test -- --[option_1] --[option_2]
   }
 }
 ```
+
+### SEARCH BY REFERENCE CODE
+
+#### Request Type
+
+`POST`
+
+#### Endpoint
+
+`/booking/search`
+
+#### JSON Payload
+
+```
+{
+  "startTime": "utc_time_format",
+  "endTime": "utc_time_format",
+  "referenceCode": "reference_code"
+}
+```
+
+#### Expected JSON Response
+
+```
+{
+  "jsonapi": {
+      "version": "1.0"
+  },
+  "data": {
+      "type": "type",
+      "id": "id",
+      "attributes": [
+        {
+            "BookingId": "bookingId",
+            "Attendees": [
+                {
+                    "Email": "email@email.com",
+                    "Type": "Required",
+                    "Status": "Declined"
+                }
+            ],
+            "Subject": "subject",
+            "Body": null,
+            "Location": "location",
+            "ReferenceCode": "reference code",
+            "StartTime": "2021-11-10T10:00:00+01:00",
+            "EndTime": "2021-11-10T11:00:00+01:00"
+        },
+      ]
+  }
+}
+```

--- a/services/booking-api/helpers/booking.js
+++ b/services/booking-api/helpers/booking.js
@@ -9,6 +9,7 @@ const URI_RESOURCE = {
   CREATE: 'booking/create',
   CANCEL: 'booking/cancel',
   GET: 'booking/get',
+  SEARCH: 'booking/search',
 };
 
 const METHOD = {
@@ -25,6 +26,10 @@ function cancel(bookingId) {
 
 function get(bookingId) {
   return sendBookingPostRequest(URI_RESOURCE.GET, { bookingId });
+}
+
+function search(body) {
+  return sendBookingPostRequest(URI_RESOURCE.SEARCH, body);
 }
 
 async function sendBookingPostRequest(path, body) {
@@ -54,4 +59,4 @@ async function getSsmParameters() {
   return response;
 }
 
-export default { create, cancel, get };
+export default { create, cancel, get, search };

--- a/services/booking-api/lambdas/searchByReferenceCode.js
+++ b/services/booking-api/lambdas/searchByReferenceCode.js
@@ -1,0 +1,26 @@
+import to from 'await-to-js';
+
+import * as response from '../../../libs/response';
+
+import booking from '../helpers/booking';
+
+export async function main(event) {
+  const body = JSON.parse(event.body);
+
+  const { referenceCode, startTime, endTime } = body;
+  if (!referenceCode || !startTime || !endTime) {
+    return response.failure({
+      status: 403,
+      message: 'Missing one of more required parameter: "referenceCode", "startTime", "endTime"',
+    });
+  }
+
+  const searchBookingBody = { referenceCode, startTime, endTime };
+  const [searchBookingError, searchBookingResponse] = await to(booking.search(searchBookingBody));
+  if (searchBookingError) {
+    return response.failure(searchBookingError);
+  }
+
+  const { data } = searchBookingResponse.data;
+  return response.success(200, data);
+}

--- a/services/booking-api/serverless.yml
+++ b/services/booking-api/serverless.yml
@@ -78,3 +78,12 @@ functions:
           method: patch
           private: true
           cors: true
+
+  searchByReferenceCode:
+    handler: lambdas/searchByReferenceCode.main
+    events:
+      - http:
+          path: booking/search
+          method: post
+          private: true
+          cors: true

--- a/services/booking-api/test/helpers/booking.test.js
+++ b/services/booking-api/test/helpers/booking.test.js
@@ -45,14 +45,25 @@ it('throws if failing making sendBookingPostRequest requests', async () => {
   }
 });
 
-test.each(['create', 'cancel', 'get'])(
-  `booking.%s makes requests against correct endpoint`,
-  async requestName => {
+test.each([
+  {
+    path: 'create',
+    functionCall: { requiredAttendees: ['mock'], startTime: '1', endTime: '2' },
+    requestCall: { requiredAttendees: ['mock'], startTime: '1', endTime: '2' },
+  },
+  { path: 'cancel', functionCall: 'mockId', requestCall: { bookingId: 'mockId' } },
+  { path: 'get', functionCall: 'mockId', requestCall: { bookingId: 'mockId' } },
+  {
+    path: 'search',
+    functionCall: { startTime: '1', endTime: '2', referenceCode: '3' },
+    requestCall: { startTime: '1', endTime: '2', referenceCode: '3' },
+  },
+])(
+  `booking $path makes requests against correct endpoint`,
+  async ({ path, functionCall, requestCall }) => {
     expect.assertions(1);
 
-    const endpoint = `${mockEndpoint}/booking/${requestName}`;
-    const requestParameter = requestName === 'create' ? { bookingId: requestName } : requestName;
-    const body = { bookingId: requestName };
+    const endpoint = `${mockEndpoint}/booking/${path}`;
     const requestClient = request.requestClient(
       { rejectUnauthorized: false },
       { 'X-ApiKey': mockApiKey }
@@ -61,8 +72,8 @@ test.each(['create', 'cancel', 'get'])(
     params.read.mockResolvedValueOnce({ datatorgetEndpoint: mockEndpoint, apiKey: mockApiKey });
     request.call.mockResolvedValueOnce();
 
-    await booking[requestName](requestParameter);
+    await booking[path](functionCall);
 
-    expect(request.call).toHaveBeenCalledWith(requestClient, 'post', endpoint, body);
+    expect(request.call).toHaveBeenCalledWith(requestClient, 'post', endpoint, requestCall);
   }
 );

--- a/services/booking-api/test/lambdas/searchByReferenceCode.test.js
+++ b/services/booking-api/test/lambdas/searchByReferenceCode.test.js
@@ -1,0 +1,116 @@
+import messages from '@helsingborg-stad/npm-api-error-handling/assets/errorMessages';
+
+import { main } from '../../lambdas/searchByReferenceCode';
+import booking from '../../helpers/booking';
+
+jest.mock('../../helpers/booking');
+
+const mockBody = {
+  startTime: '2021-11-01T00:00:00+01:00',
+  endTime: '2021-12-31T00:00:00+01:00',
+  referenceCode: 'mockReferenceCode',
+};
+const mockEvent = {
+  body: JSON.stringify(mockBody),
+};
+const mockHeaders = {
+  'Access-Control-Allow-Credentials': true,
+  'Access-Control-Allow-Origin': '*',
+};
+
+const mockCalendarSearch = [
+  {
+    BookingId: '123456789',
+    Attendees: [
+      {
+        Email: 'test@mail.com',
+        Type: 'Required',
+        Status: 'Accepted',
+      },
+    ],
+    Subject: ' ##attempt_1',
+    Body: null,
+    Location: 'plats',
+    ReferenceCode: 'attempt_1',
+    StartTime: '2021-11-10T10:00:00+01:00',
+    EndTime: '2021-11-10T11:00:00+01:00',
+  },
+];
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+it('gets booking from a successful search', async () => {
+  expect.assertions(2);
+
+  const expectedResult = {
+    body: JSON.stringify({ jsonapi: { version: '1.0' }, data: { attributes: mockCalendarSearch } }),
+    headers: mockHeaders,
+    statusCode: 200,
+  };
+
+  booking.search.mockResolvedValueOnce({
+    data: {
+      data: {
+        attributes: mockCalendarSearch,
+      },
+    },
+  });
+
+  const result = await main(mockEvent);
+
+  expect(result).toEqual(expectedResult);
+  expect(booking.search).toHaveBeenCalledWith(mockBody);
+});
+
+it('throws when searching for a booking fails', async () => {
+  expect.assertions(1);
+
+  const statusCode = 500;
+  const message = messages[statusCode];
+  const expectedResult = {
+    body: JSON.stringify({
+      jsonapi: { version: '1.0' },
+      data: {
+        status: '500',
+        code: '500',
+        message,
+      },
+    }),
+    headers: mockHeaders,
+    statusCode,
+  };
+
+  booking.search.mockRejectedValueOnce({ status: statusCode, message });
+
+  const result = await main(mockEvent);
+
+  expect(result).toEqual(expectedResult);
+});
+
+it('returns failure if required paramerer is missing', async () => {
+  expect.assertions(2);
+
+  const event = {
+    body: JSON.stringify({ startTime: '2021-11-01T00:00:00+01:00' }),
+  };
+
+  const expectedResult = {
+    body: JSON.stringify({
+      jsonapi: { version: '1.0' },
+      data: {
+        status: '403',
+        code: '403',
+        message: 'Missing one of more required parameter: "referenceCode", "startTime", "endTime"',
+      },
+    }),
+    headers: mockHeaders,
+    statusCode: 403,
+  };
+
+  const result = await main(event);
+
+  expect(result).toEqual(expectedResult);
+  expect(booking.search).toHaveBeenCalledTimes(0);
+});


### PR DESCRIPTION
# What was solved
Added a new endpoint for searching for bookings by their reference code. The endpoint is going to be used for searching for that have happen.

# How was it solved
Added new endpoint which takes 3 parameters in its body, startTime, endTime and referenceCode. This parameters is then used for making requests against datatorget.

# Why was it solved in this way
This follow how we are making requests with the lambda function in the same service.

# How was it tested
Tested by deploying the service and making request with postman.