### PR TITLE
feat: added get endpoint for fetching historical attendees

### DIFF
--- a/services/booking-api/README.md
+++ b/services/booking-api/README.md
@@ -254,3 +254,36 @@ $ npm run test -- --[option_1] --[option_2]
   }
 }
 ```
+
+### GET HISTORICAL ATTENDEES
+
+#### Request Type
+
+`GET`
+
+#### Endpoint
+
+`/booking/getHistoricalAttendees/{referenceCode}?startTime{ISO-string}&endTime{ISO-string}`
+
+#### JSON Payload
+
+`N/A`
+
+#### Expected JSON Response
+
+```
+{
+  "jsonapi": {
+      "version": "1.0"
+  },
+  "data": {
+      "type": "type",
+      "id": "id",
+      "attributes": [
+          "email_1",
+          "email_2
+          ...
+      ]
+  }
+}
+```

--- a/services/booking-api/helpers/booking.js
+++ b/services/booking-api/helpers/booking.js
@@ -10,6 +10,7 @@ const URI_RESOURCE = {
   CANCEL: 'booking/cancel',
   GET: 'booking/get',
   SEARCH: 'booking/search',
+  GET_HISTORICAL_ATTENDEES: 'booking/getHistoricalAttendees',
 };
 
 const METHOD = {
@@ -30,6 +31,10 @@ function get(bookingId) {
 
 function search(body) {
   return sendBookingPostRequest(URI_RESOURCE.SEARCH, body);
+}
+
+function getHistoricalAttendees(body) {
+  return sendBookingPostRequest(URI_RESOURCE.GET_HISTORICAL_ATTENDEES, body);
 }
 
 async function sendBookingPostRequest(path, body) {
@@ -59,4 +64,4 @@ async function getSsmParameters() {
   return response;
 }
 
-export default { create, cancel, get, search };
+export default { create, cancel, get, search, getHistoricalAttendees };

--- a/services/booking-api/lambdas/getHistoricalAttendees.js
+++ b/services/booking-api/lambdas/getHistoricalAttendees.js
@@ -5,8 +5,6 @@ import * as response from '../../../libs/response';
 import booking from '../helpers/booking';
 
 export async function main(event) {
-  console.log('EVENT: ', JSON.stringify(event, undefined));
-
   let referenceCode = event.pathParameters?.referenceCode;
 
   if (!referenceCode) {

--- a/services/booking-api/lambdas/getHistoricalAttendees.js
+++ b/services/booking-api/lambdas/getHistoricalAttendees.js
@@ -1,0 +1,39 @@
+import to from 'await-to-js';
+
+import * as response from '../../../libs/response';
+
+import booking from '../helpers/booking';
+
+export async function main(event) {
+  console.log('EVENT: ', JSON.stringify(event, undefined));
+
+  let referenceCode = event.pathParameters?.referenceCode;
+
+  if (!referenceCode) {
+    return response.failure({
+      status: 403,
+      message: 'Missing required parameter: "referenceCode"',
+    });
+  }
+
+  referenceCode = decodeURIComponent(referenceCode);
+  const { startTime = '', endTime = '' } = event.queryStringParameters;
+
+  if (!startTime | !endTime) {
+    return response.failure({
+      status: 403,
+      message: 'Missing one or more required query string parameters: "startTime", "endTime',
+    });
+  }
+
+  const getHistoricalAttendeesBody = { referenceCode, startTime, endTime };
+  const [searchBookingError, searchBookingResponse] = await to(
+    booking.getHistoricalAttendees(getHistoricalAttendeesBody)
+  );
+  if (searchBookingError) {
+    return response.failure(searchBookingError);
+  }
+
+  const { data } = searchBookingResponse.data;
+  return response.success(200, data);
+}

--- a/services/booking-api/lambdas/getHistoricalAttendees.js
+++ b/services/booking-api/lambdas/getHistoricalAttendees.js
@@ -27,13 +27,13 @@ export async function main(event) {
   }
 
   const getHistoricalAttendeesBody = { referenceCode, startTime, endTime };
-  const [searchBookingError, searchBookingResponse] = await to(
+  const [getHistoricalAttendeesError, getHistoricalAttendeesResponse] = await to(
     booking.getHistoricalAttendees(getHistoricalAttendeesBody)
   );
-  if (searchBookingError) {
-    return response.failure(searchBookingError);
+  if (getHistoricalAttendeesError) {
+    return response.failure(getHistoricalAttendeesError);
   }
 
-  const { data } = searchBookingResponse.data;
+  const { data } = getHistoricalAttendeesResponse.data;
   return response.success(200, data);
 }

--- a/services/booking-api/serverless.yml
+++ b/services/booking-api/serverless.yml
@@ -87,3 +87,12 @@ functions:
           method: post
           private: true
           cors: true
+
+  getHistoricalAttendees:
+    handler: lambdas/getHistoricalAttendees.main
+    events:
+      - http:
+          path: booking/getHistoricalAttendees/{referenceCode}
+          method: get
+          private: true
+          cors: true

--- a/services/booking-api/test/helpers/booking.test.js
+++ b/services/booking-api/test/helpers/booking.test.js
@@ -58,6 +58,11 @@ test.each([
     functionCall: { startTime: '1', endTime: '2', referenceCode: '3' },
     requestCall: { startTime: '1', endTime: '2', referenceCode: '3' },
   },
+  {
+    path: 'getHistoricalAttendees',
+    functionCall: { startTime: '1', endTime: '2', referenceCode: '3' },
+    requestCall: { startTime: '1', endTime: '2', referenceCode: '3' },
+  },
 ])(
   `booking $path makes requests against correct endpoint`,
   async ({ path, functionCall, requestCall }) => {

--- a/services/booking-api/test/lambdas/getHistoricalAttendees.test.js
+++ b/services/booking-api/test/lambdas/getHistoricalAttendees.test.js
@@ -1,0 +1,120 @@
+// import messages from '@helsingborg-stad/npm-api-error-handling/assets/errorMessages';
+
+import { main } from '../../lambdas/getHistoricalAttendees';
+import booking from '../../helpers/booking';
+
+jest.mock('../../helpers/booking');
+
+const mockHeaders = {
+  'Access-Control-Allow-Credentials': true,
+  'Access-Control-Allow-Origin': '*',
+};
+
+const mockCalendarBooking = {
+  type: 'bookings',
+  id: '123456789',
+  attributes: ['outlook_1@helsingborg.se', 'outlook_2@helsingborg.se'],
+};
+
+const getHistoricalAttendeesMockData = {
+  jsonapi: { version: '1.0' },
+  data: mockCalendarBooking,
+};
+
+const mockReferenceCode = '1a2bc3';
+const mockStartTime = 'startTime';
+const mockEndTime = 'mockEndTime';
+let mockEvent;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  mockEvent = {
+    pathParameters: {
+      referenceCode: mockReferenceCode,
+    },
+    queryStringParameters: {
+      startTime: mockStartTime,
+      endTime: mockEndTime,
+    },
+  };
+});
+
+it('gets historical attendees successfully', async () => {
+  expect.assertions(3);
+
+  const expectedResult = {
+    body: JSON.stringify(getHistoricalAttendeesMockData),
+    headers: mockHeaders,
+    statusCode: 200,
+  };
+
+  booking.getHistoricalAttendees.mockResolvedValueOnce({
+    data: {
+      data: mockCalendarBooking,
+    },
+  });
+
+  const result = await main(mockEvent);
+
+  expect(result).toEqual(expectedResult);
+  expect(booking.getHistoricalAttendees).toHaveBeenCalledTimes(1);
+  expect(booking.getHistoricalAttendees).toHaveBeenCalledWith({
+    referenceCode: mockReferenceCode,
+    startTime: mockStartTime,
+    endTime: mockEndTime,
+  });
+});
+
+it('returns failure if "referenceCode" is not provided as path parameter', async () => {
+  expect.assertions(2);
+
+  mockEvent.pathParameters.referenceCode = undefined;
+  const statusCode = 403;
+  const message = 'Missing required parameter: "referenceCode"';
+
+  const expectedResult = {
+    body: JSON.stringify({
+      jsonapi: { version: '1.0' },
+      data: {
+        status: '403',
+        code: '403',
+        message,
+      },
+    }),
+    headers: mockHeaders,
+    statusCode,
+  };
+
+  const result = await main(mockEvent);
+
+  expect(result).toEqual(expectedResult);
+  expect(booking.getHistoricalAttendees).toHaveBeenCalledTimes(0);
+});
+
+it('returns failure if one of required query strings parameters does not exist', async () => {
+  expect.assertions(2);
+
+  mockEvent.queryStringParameters.startTime = undefined;
+
+  const statusCode = 403;
+  const message = 'Missing one or more required query string parameters: "startTime", "endTime';
+
+  const expectedResult = {
+    body: JSON.stringify({
+      jsonapi: { version: '1.0' },
+      data: {
+        status: '403',
+        code: '403',
+        message,
+      },
+    }),
+    headers: mockHeaders,
+    statusCode,
+  };
+
+  const result = await main(mockEvent);
+
+  expect(result).toEqual(expectedResult);
+  expect(booking.getHistoricalAttendees).toHaveBeenCalledTimes(0);
+});

--- a/services/booking-api/test/lambdas/getHistoricalAttendees.test.js
+++ b/services/booking-api/test/lambdas/getHistoricalAttendees.test.js
@@ -1,5 +1,3 @@
-// import messages from '@helsingborg-stad/npm-api-error-handling/assets/errorMessages';
-
 import { main } from '../../lambdas/getHistoricalAttendees';
 import booking from '../../helpers/booking';
 

--- a/services/booking-api/test/lambdas/getHistoricalAttendees.test.js
+++ b/services/booking-api/test/lambdas/getHistoricalAttendees.test.js
@@ -118,3 +118,30 @@ it('returns failure if one of required query strings parameters does not exist',
   expect(result).toEqual(expectedResult);
   expect(booking.getHistoricalAttendees).toHaveBeenCalledTimes(0);
 });
+
+it('returns failure if datatorget request fails', async () => {
+  expect.assertions(2);
+
+  const statusCode = 500;
+  const message = 'error';
+
+  const expectedResult = {
+    body: JSON.stringify({
+      jsonapi: { version: '1.0' },
+      data: {
+        status: '500',
+        code: '500',
+        message,
+      },
+    }),
+    headers: mockHeaders,
+    statusCode,
+  };
+
+  booking.getHistoricalAttendees.mockRejectedValueOnce({ status: statusCode, message });
+
+  const result = await main(mockEvent);
+
+  expect(result).toEqual(expectedResult);
+  expect(booking.getHistoricalAttendees).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
# What was solved
Added new endpoint for fetching historical attendees, i.e. attendees which is used as a users "network" within the application.

# How was it solved
Added a new GET endpoint which takes the referenceCode as path parameter and startTime and endTime as required query string parameters.

# Why was it solved in this way
The reason for using GET rather than POST method is because we want the endpoint to be as much REST as possible. 

# How was it tested
Tested created a new calendar booking with a specific referenceCode. Took that referenceCode and tried it out with the new endpoint. Checked the result that was returned in postman.