### PR TITLE
fix(viva-ms): added missing constants in viva-ms helpers/constants

### DIFF
--- a/services/viva-ms/helpers/constans.js
+++ b/services/viva-ms/helpers/constans.js
@@ -43,3 +43,25 @@ export const PERSON_ROLE = {
   coApplicant: 'coApplicant',
   children: 'children',
 };
+
+export const EMPTY_INCOME_POST = {
+  type: 'income',
+  group: '',
+  belongsTo: 'APPLICANT',
+  title: '',
+  description: '',
+  date: '',
+  value: '',
+  currency: 'kr',
+};
+
+export const EMPTY_EXPENSE_POST = {
+  type: 'expense',
+  group: '',
+  belongsTo: 'APPLICANT',
+  title: '',
+  description: '',
+  date: '',
+  value: '',
+  currency: 'kr',
+};


### PR DESCRIPTION
Constants for empty income and expense post was missing in the constants.js files. These have been
added in order for other helper functions to work properly