### PR TITLE
Fix/remove translation in template

### DIFF
--- a/services/html-pdf-ms/templates/ekb-recurring.hbs
+++ b/services/html-pdf-ms/templates/ekb-recurring.hbs
@@ -126,27 +126,7 @@
         <tr>
           <td>Sysselsättning</td>
           <td>
-            {{#if (eq this.occupation 'fulltime')}}
-            Arbetar heltid
-            {{/if}}
-            {{#if (eq this.occupation 'parttime')}}
-            Arbetar deltid
-            {{/if}}
-            {{#if (eq this.occupation 'unemployed')}}
-            Arbetssökande
-            {{/if}}
-            {{#if (eq this.occupation 'parentalleave')}}
-            Föräldraledig
-            {{/if}}
-            {{#if (eq this.occupation 'studies')}}
-            Studerande
-            {{/if}}
-            {{#if (eq this.occupation 'sick')}}
-            Sjukskriven med läkarintyg
-            {{/if}}
-            {{#if (eq this.occupation 'otheroccuption')}}
-            Annat
-            {{/if}}
+            {{this.occupation}}
           </td>
         </tr>
       </table>
@@ -219,33 +199,7 @@
         <tr>
           <td>Boendeform</td>
           <td>
-            {{#if (eq this.contract 'lease')}}
-            Hyresrätt/förstahandskontrakt
-            {{/if}}
-            {{#if (eq this.contract 'sublease')}}
-            Andrahandskontrakt
-            {{/if}}
-            {{#if (eq this.contract 'rentasRoommate')}}
-            Inneboende
-            {{/if}}
-            {{#if (eq this.contract 'livingatParents')}}
-            Bor hos föräldrar
-            {{/if}}
-            {{#if (eq this.contract 'livingatChild')}}
-            Bor hus vuxna barn
-            {{/if}}
-            {{#if (eq this.contract 'condo')}}
-            Bostadsrätt
-            {{/if}}
-            {{#if (eq this.contract 'ownHouse')}}
-            Eget hus
-            {{/if}}
-            {{#if (eq this.contract 'noHome')}}
-            Bostadslös
-            {{/if}}
-            {{#if (eq this.contract 'otherLiving')}}
-            Annat boende
-            {{/if}}
+            {{this.contract}}
           </td>
         </tr>
         <tr>


### PR DESCRIPTION

## Explain the changes you’ve made

Removed translation in template from english keywords to swedish labels.

## Explain why these changes are made

Some values did not show due to some values was hard-coded in the template. If these conditions where false, no value was shown, even if a correct value was passed in terms of what should end up in the final html output.

## Explain your solution

The solution was to simply remove the conditions where we check for certain values from the template and just let the value render as it is. This means that the value from a form answer will be displayed as it is, control of language is thereby handled in the form creation process in favour for handling these conditions in the template.

## How to test the changes?
1. Upload the template to s3 (pdf-storage.../templates).
2. Submit a form with decrypted answers towards the /cases endpoint.
3. Make sure that answers submitted contains information regarding occupation and housing contract.
4. Check the generated html in s3 to se if the value passed in the answer is displayed. Or check the final PDF that is generated. These can be located in the same s3 bucket (pdf-storage...).

## Was this feature tested in the following environments?
- [x] Personal AWS Sandbox.