### PR TITLE
Fix/pass state in event

### DIFF
--- a/services/cases-api/lambdas/updateCase.js
+++ b/services/cases-api/lambdas/updateCase.js
@@ -173,7 +173,7 @@ export async function main(event, context) {
 
   const [putEventError] = await to(
     putEvent(
-      { caseKeys, status: newCaseStatus },
+      { caseKeys, status: newCaseStatus, state: userCase.state },
       'casesApiUpdateCaseSuccess',
       'casesApi.updateCase'
     )

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -243,3 +243,5 @@ functions:
             detail:
               status:
                 type: [{ "prefix": "active:submitted" }]
+              state:
+                type: ["VIVA_CASE_CREATED"]


### PR DESCRIPTION
## Explain the changes you’ve made
I've added the possibility of reacting to the case state after a case have been updated through the caseUpdate lambda. The generateRecurringCaseHtml lambda listen and reacts to this new detail attribute.

## Explain why these changes are made
The generateRecurringCaseHtml fired on occasions when it should not. This is due to that the status ("active:submitted") is set on several occasions throughout a case's life-span, but the pdf should only be generated once when state is "VIVA_CASE_CREATED" and the status is "active:submitted".
