### PR TITLE
Fix/spacing beetween tables

### DIFF
--- a/.deploy/cloudformation/pipelines/release/stack.yml
+++ b/.deploy/cloudformation/pipelines/release/stack.yml
@@ -18,7 +18,7 @@ Parameters:
   GitHubBranch:
     Description: Branch name.
     Type: String
-    Default: release/1.2.2
+    Default: release/1.2.3
   GitHubNPMToken:
     Description: Access token for github npm packages
     Type: AWS::SSM::Parameter::Value<String>
@@ -48,8 +48,6 @@ Resources:
         Location: !Sub "${S3BucketArtifact}/cache"
         Type: S3
 
-
-
   ##
   # CodePipeline
   ##
@@ -74,7 +72,7 @@ Resources:
                 Version: "1"
                 Provider: CodeStarSourceConnection
               Configuration:
-                ConnectionArn: 
+                ConnectionArn:
                   Fn::ImportValue: github-connection-CodeStarConnection
                 FullRepositoryId: !Sub "${GitHubOwner}/${GitHubRepo}"
                 BranchName: !Ref GitHubBranch
@@ -84,8 +82,7 @@ Resources:
               RunOrder: 1
         - Name: Release
           Actions:
-            -
-              Name: DeployRelease
+            - Name: DeployRelease
               ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -108,12 +105,9 @@ Resources:
                       "value": "release"
                     }
                   ]
-              InputArtifacts: 
-                - 
-                  Name: SourceOutput
+              InputArtifacts:
+                - Name: SourceOutput
               RunOrder: 1
-
-
 
   ##
   # IAM
@@ -140,31 +134,27 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - s3:*
             Resource:
               - !Sub arn:aws:s3:::${S3BucketArtifact}/*
               - !Sub arn:aws:s3:::${S3BucketArtifact}
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - kms:Decrypt
             Resource: !GetAtt KMSKey.Arn
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: arn:aws:logs:*:*:*
-          -
-            Sid: cloudformation
+          - Sid: cloudformation
             Effect: Allow
             Action:
               - cloudformation:ValidateTemplate
-            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:*'
+            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:*"
           - Sid: iam
             Effect: Allow
             Action:
@@ -187,8 +177,7 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Principal:
               Service:
                 - codepipeline.amazonaws.com
@@ -241,8 +230,6 @@ Resources:
       Roles:
         - !Ref IAMRolePipeline
 
-
-
   ##
   # KMS
   ##
@@ -256,8 +243,7 @@ Resources:
         Version: 2012-10-17
         Id: Key
         Statement:
-          -
-            Sid: Allows admin of the key
+          - Sid: Allows admin of the key
             Effect: Allow
             Principal:
               AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
@@ -275,8 +261,7 @@ Resources:
               - kms:ScheduleKeyDeletion
               - kms:CancelKeyDeletion
             Resource: "*"
-          -
-            Sid: Allow use of the key for CryptoGraphy Lambda
+          - Sid: Allow use of the key for CryptoGraphy Lambda
             Effect: Allow
             Principal:
               AWS:
@@ -295,8 +280,6 @@ Resources:
     Properties:
       AliasName: !Sub alias/${AWS::StackName}-xaccounts
       TargetKeyId: !Ref KMSKey
-
-
 
   ##
   # S3

--- a/services/html-pdf-ms/templates/ekb-recurring.hbs
+++ b/services/html-pdf-ms/templates/ekb-recurring.hbs
@@ -27,6 +27,7 @@
         border-spacing: 0px;
         border: none;
         font-size: 20px;
+        margin-bottom: 20px;
       }
 
       tr {


### PR DESCRIPTION
Added margin at the bottom of each table in the handlebars template, in order for tables to not appear as one in the generated pdf.