### PR TITLE
Feat/show expenses for children

### DIFF
--- a/services/viva-ms/helpers/createRecurringCaseTemplate.js
+++ b/services/viva-ms/helpers/createRecurringCaseTemplate.js
@@ -342,6 +342,7 @@ function getFinancials(answers) {
     expenses: {
       applicant: applicantsExpenses.filter(expense => expense.belongsTo === 'APPLICANT'),
       coApplicant: applicantsExpenses.filter(expense => expense.belongsTo === 'COAPPLICANT'),
+      children: applicantsExpenses.filter(expense => expense.belongsTo === 'CHILDREN'),
       housing: housingExpenses,
     },
   };


### PR DESCRIPTION
## Feature description
Adding expenses for children to template data object.

## Solution description
Expenses that applies to children in the application have been filtered out and added to the template data object under `financials.expenses.children`

## What areas is affected by these changes?.
viva-ms service and template in html-pdf-ms

## Is there any exsisting behavior change of other features due to this code change?
No

## Covered unit tests cases / E2E test cases?
No


## Was this feature tested in the following environments?
- [x] Your personal AWS environment.
- [] Your local Serverless environment.