### PR TITLE
Feat/build template notes data from tags

### DIFF
--- a/.deploy/cloudformation/pipelines/release/stack.yml
+++ b/.deploy/cloudformation/pipelines/release/stack.yml
@@ -48,8 +48,6 @@ Resources:
         Location: !Sub "${S3BucketArtifact}/cache"
         Type: S3
 
-
-
   ##
   # CodePipeline
   ##
@@ -74,7 +72,7 @@ Resources:
                 Version: "1"
                 Provider: CodeStarSourceConnection
               Configuration:
-                ConnectionArn: 
+                ConnectionArn:
                   Fn::ImportValue: github-connection-CodeStarConnection
                 FullRepositoryId: !Sub "${GitHubOwner}/${GitHubRepo}"
                 BranchName: !Ref GitHubBranch
@@ -84,8 +82,7 @@ Resources:
               RunOrder: 1
         - Name: Release
           Actions:
-            -
-              Name: DeployRelease
+            - Name: DeployRelease
               ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -108,12 +105,9 @@ Resources:
                       "value": "release"
                     }
                   ]
-              InputArtifacts: 
-                - 
-                  Name: SourceOutput
+              InputArtifacts:
+                - Name: SourceOutput
               RunOrder: 1
-
-
 
   ##
   # IAM
@@ -140,31 +134,27 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - s3:*
             Resource:
               - !Sub arn:aws:s3:::${S3BucketArtifact}/*
               - !Sub arn:aws:s3:::${S3BucketArtifact}
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - kms:Decrypt
             Resource: !GetAtt KMSKey.Arn
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: arn:aws:logs:*:*:*
-          -
-            Sid: cloudformation
+          - Sid: cloudformation
             Effect: Allow
             Action:
               - cloudformation:ValidateTemplate
-            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:*'
+            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:*"
           - Sid: iam
             Effect: Allow
             Action:
@@ -187,8 +177,7 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Principal:
               Service:
                 - codepipeline.amazonaws.com
@@ -241,8 +230,6 @@ Resources:
       Roles:
         - !Ref IAMRolePipeline
 
-
-
   ##
   # KMS
   ##
@@ -256,8 +243,7 @@ Resources:
         Version: 2012-10-17
         Id: Key
         Statement:
-          -
-            Sid: Allows admin of the key
+          - Sid: Allows admin of the key
             Effect: Allow
             Principal:
               AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
@@ -275,8 +261,7 @@ Resources:
               - kms:ScheduleKeyDeletion
               - kms:CancelKeyDeletion
             Resource: "*"
-          -
-            Sid: Allow use of the key for CryptoGraphy Lambda
+          - Sid: Allow use of the key for CryptoGraphy Lambda
             Effect: Allow
             Principal:
               AWS:
@@ -295,8 +280,6 @@ Resources:
     Properties:
       AliasName: !Sub alias/${AWS::StackName}-xaccounts
       TargetKeyId: !Ref KMSKey
-
-
 
   ##
   # S3

--- a/.deploy/cloudformation/pipelines/release/stack.yml
+++ b/.deploy/cloudformation/pipelines/release/stack.yml
@@ -48,6 +48,8 @@ Resources:
         Location: !Sub "${S3BucketArtifact}/cache"
         Type: S3
 
+
+
   ##
   # CodePipeline
   ##
@@ -72,7 +74,7 @@ Resources:
                 Version: "1"
                 Provider: CodeStarSourceConnection
               Configuration:
-                ConnectionArn:
+                ConnectionArn: 
                   Fn::ImportValue: github-connection-CodeStarConnection
                 FullRepositoryId: !Sub "${GitHubOwner}/${GitHubRepo}"
                 BranchName: !Ref GitHubBranch
@@ -82,7 +84,8 @@ Resources:
               RunOrder: 1
         - Name: Release
           Actions:
-            - Name: DeployRelease
+            -
+              Name: DeployRelease
               ActionTypeId:
                 Category: Build
                 Owner: AWS
@@ -105,9 +108,12 @@ Resources:
                       "value": "release"
                     }
                   ]
-              InputArtifacts:
-                - Name: SourceOutput
+              InputArtifacts: 
+                - 
+                  Name: SourceOutput
               RunOrder: 1
+
+
 
   ##
   # IAM
@@ -134,27 +140,31 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow
+          -
+            Effect: Allow
             Action:
               - s3:*
             Resource:
               - !Sub arn:aws:s3:::${S3BucketArtifact}/*
               - !Sub arn:aws:s3:::${S3BucketArtifact}
-          - Effect: Allow
+          -
+            Effect: Allow
             Action:
               - kms:Decrypt
             Resource: !GetAtt KMSKey.Arn
-          - Effect: Allow
+          -
+            Effect: Allow
             Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: arn:aws:logs:*:*:*
-          - Sid: cloudformation
+          -
+            Sid: cloudformation
             Effect: Allow
             Action:
               - cloudformation:ValidateTemplate
-            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:*"
+            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:*'
           - Sid: iam
             Effect: Allow
             Action:
@@ -177,7 +187,8 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow
+          -
+            Effect: Allow
             Principal:
               Service:
                 - codepipeline.amazonaws.com
@@ -230,6 +241,8 @@ Resources:
       Roles:
         - !Ref IAMRolePipeline
 
+
+
   ##
   # KMS
   ##
@@ -243,7 +256,8 @@ Resources:
         Version: 2012-10-17
         Id: Key
         Statement:
-          - Sid: Allows admin of the key
+          -
+            Sid: Allows admin of the key
             Effect: Allow
             Principal:
               AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
@@ -261,7 +275,8 @@ Resources:
               - kms:ScheduleKeyDeletion
               - kms:CancelKeyDeletion
             Resource: "*"
-          - Sid: Allow use of the key for CryptoGraphy Lambda
+          -
+            Sid: Allow use of the key for CryptoGraphy Lambda
             Effect: Allow
             Principal:
               AWS:
@@ -280,6 +295,8 @@ Resources:
     Properties:
       AliasName: !Sub alias/${AWS::StackName}-xaccounts
       TargetKeyId: !Ref KMSKey
+
+
 
   ##
   # S3

--- a/services/viva-ms/helpers/createRecurringCaseTemplate.js
+++ b/services/viva-ms/helpers/createRecurringCaseTemplate.js
@@ -99,16 +99,11 @@ function createChildren(answers) {
 }
 
 function createNotes(answers) {
-  const notes = [];
-  const filteredAnswers = formHelpers.filterByFieldIdIncludes(answers, 'otherMessage');
-  if (filteredAnswers.length) {
-    const [noteAnswer] = filteredAnswers;
-    const note = {
-      title: 'Meddelande från sökande',
-      text: noteAnswer.value,
-    };
-    notes.push(note);
-  }
+  const noteAnswers = formHelpers.filterByTags(answers, ['notes', 'note']);
+  const notes = noteAnswers.map(answer => ({
+    title: 'Meddelande från sökande',
+    text: answer.value,
+  }));
   return notes;
 }
 


### PR DESCRIPTION
## Feature description
Added support for parsing multiple notes answers into a handlebars template.

## Solution description
Before the creation of notes in the template helper only supported the retrieval of one field based on a hardcoded id. 

Now the creation of notes in the template helper is based on retrieval of multiple notes answers based on tags. We simply filter out answers that contains the tags `notes`, `note` and then a note object is created for each answer and return as an array of notes to the template.

## What areas is affected by these changes?.
viva-ms 

## Is there any existing behavior change of other features due to this code change?
Yes. The form needs to be updated with correct tagging on certain fields in order for notes to be passed into the handlebars template. If this is not corrected the pdf that is generated in the service html-pdf-ms will not contain any notes at all. 

## Covered unit tests cases / E2E test cases?
No

## Was this feature tested in the following environments?
- [x] Your personal AWS environment.
- [] Your local Serverless environment.