### PR TITLE
fix: make gethistoricalattendees not timeout

### DIFF
--- a/services/booking-api/helpers/booking.js
+++ b/services/booking-api/helpers/booking.js
@@ -34,15 +34,17 @@ function search(body) {
 }
 
 function getHistoricalAttendees(body) {
-  return sendBookingPostRequest(URI_RESOURCE.GET_HISTORICAL_ATTENDEES, body);
+  const requestTimeout = process.env.requestTimeout;
+  return sendBookingPostRequest(URI_RESOURCE.GET_HISTORICAL_ATTENDEES, body, requestTimeout);
 }
 
-async function sendBookingPostRequest(path, body) {
+async function sendBookingPostRequest(path, body, requestTimeout) {
   const { datatorgetEndpoint, apiKey } = await getSsmParameters();
 
   const requestClient = request.requestClient(
     { rejectUnauthorized: false },
-    { 'X-ApiKey': apiKey }
+    { 'X-ApiKey': apiKey },
+    requestTimeout
   );
 
   const url = `${datatorgetEndpoint}/${path}`;

--- a/services/booking-api/serverless.yml
+++ b/services/booking-api/serverless.yml
@@ -90,6 +90,9 @@ functions:
 
   getHistoricalAttendees:
     handler: lambdas/getHistoricalAttendees.main
+    timeout: 12 # time in seconds
+    environment:
+      requestTimeout: 10000 # 10 seconds in ms
     events:
       - http:
           path: booking/getHistoricalAttendees/{referenceCode}


### PR DESCRIPTION
# What was solved
Solved the issue were getHistoricalAttendees request would fail because of axios timeout.

# How was it solved
Solved it by increasing the requestTimeout when when doing the getHistoricalAttendees request by adding an environment variable to the lambda function. 

# Why was it solved in this way
Since the request takes more time than 5 seconds, we wanted to increase it in order for the request to be successful. By adding the timeout as an environment variable, we can manually change it for troubleshooting if it happens again.

# How was it tested
Tested it by deploying the solution and see if the request did timeout or not.