### PR TITLE
fix: check if timeslot is available before creating booking

### DIFF
--- a/services/booking-api/lambdas/create.js
+++ b/services/booking-api/lambdas/create.js
@@ -17,6 +17,17 @@ export async function main(event) {
     });
   }
 
+  const searchBookingBody = { startTime, endTime };
+  const [searchBookingError, searchResponse] = await to(booking.search(searchBookingBody));
+  if (searchBookingError) {
+    return response.failure(searchBookingError);
+  }
+
+  const timeslotTaken = searchResponse?.data?.data?.attributes.length > 0;
+  if (timeslotTaken) {
+    return response.failure({ message: 'Timeslot not available for booking', status: 500 });
+  }
+
   const createBookingBody = getCreateBookingBody(body);
   const [error, createBookingResponse] = await to(booking.create(createBookingBody));
   if (error) {

--- a/services/booking-api/test/lambdas/create.test.js
+++ b/services/booking-api/test/lambdas/create.test.js
@@ -44,6 +44,7 @@ it('creates a booking successfully', async () => {
     statusCode: 200,
   };
 
+  booking.search.mockResolvedValueOnce();
   booking.create.mockResolvedValueOnce({ data: responseData });
 
   const result = await main(mockEvent);
@@ -70,6 +71,7 @@ it('throws when booking.create fails', async () => {
     statusCode,
   };
 
+  booking.search.mockResolvedValueOnce();
   booking.create.mockRejectedValueOnce({ status: statusCode, message });
 
   const result = await main(mockEvent);
@@ -106,4 +108,28 @@ it('returns error when required parameters does not exists in event', async () =
 
   expect(result).toEqual(expectedResult);
   expect(booking.create).toHaveBeenCalledTimes(0);
+});
+
+it('returns failure when timeslot is already taken', async () => {
+  expect.assertions(1);
+
+  const statusCode = 500;
+  const expectedResult = {
+    body: JSON.stringify({
+      jsonapi: { version: '1.0' },
+      data: {
+        status: '500',
+        code: '500',
+        message: 'Timeslot not available for booking',
+      },
+    }),
+    headers: mockHeaders,
+    statusCode,
+  };
+
+  booking.search.mockResolvedValueOnce({ data: { data: { attributes: [{ dummy: 'yes' }] } } });
+
+  const result = await main(mockEvent);
+
+  expect(result).toEqual(expectedResult);
 });


### PR DESCRIPTION
# What was solved
Check if timeslot is available before creating a booking

# How was it solved
Solved it by first search within startTime and endTime if a booking is returned or not. If the response come back empty, then we can create a new booking. Otherwise return failure.

# Why was it solved in this way
Searching for a booking with datatorget search endpoint is the only way to check if we can create a new booking within given timespan or not. 

# How was it tested
Tested it by deploying the solution, created a booking within a timespan and tried to create a new booking with the same timespan. The second attempt failed, which means that the logic works.