### PR TITLE
fix: coapplicant headings in pdf

### DIFF
--- a/services/viva-ms/helpers/createRecurringCaseTemplate.js
+++ b/services/viva-ms/helpers/createRecurringCaseTemplate.js
@@ -331,12 +331,16 @@ function getFinancials(answers) {
   return {
     incomes: {
       applicant: applicantsIncomes.filter(income => income.belongsTo === 'APPLICANT'),
-      coApplicant: applicantsIncomes.filter(income => income.belongsTo === 'COAPPLICANT'),
+      coApplicant: applicantsIncomes.filter(
+        income => income.belongsTo === 'COAPPLICANT' && income.value !== ''
+      ),
       resident: redsidentIncomes,
     },
     expenses: {
       applicant: applicantsExpenses.filter(expense => expense.belongsTo === 'APPLICANT'),
-      coApplicant: applicantsExpenses.filter(expense => expense.belongsTo === 'COAPPLICANT'),
+      coApplicant: applicantsExpenses.filter(
+        expense => expense.belongsTo === 'COAPPLICANT' && expense.value !== ''
+      ),
       children: applicantsExpenses.filter(expense => expense.belongsTo === 'CHILDREN'),
       housing: housingExpenses,
     },


### PR DESCRIPTION
While there is no coapplicant on a case, some headings were still visible in the pdf.
This not-so-elegant solution is to filter of items having an empty value.
