### PR TITLE
feat: allow putobject on encrypted bucket

### DIFF
--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -82,6 +82,7 @@ provider:
         - Effect: Allow
           Action:
             - kms:Decrypt
+            - kms:GenerateDataKey
           Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:


### PR DESCRIPTION
To allow a put object on an encrypted bucket, the action kms:GenerateDataKey must be allowed for the calling lambda.
