### PR TITLE
fix: upload api crashes when payload is empty

### DIFF
--- a/services/users-api/lambdas/uploadAttachment.js
+++ b/services/users-api/lambdas/uploadAttachment.js
@@ -15,6 +15,12 @@ const allowedMimes = ['image/jpeg', 'image/png', 'image/jpg', 'application/pdf']
 export async function main(event, context) {
   const decodedToken = decodeToken(event);
 
+  if (!event?.body) {
+    const errorMessage = 'Body data is missing in request';
+    log.error(errorMessage, context.awsRequestId, 'service-users-api-uploadAttachment-000');
+    return response.failure(new BadRequestError(errorMessage));
+  }
+
   const { fileName, mime } = JSON.parse(event.body);
 
   if (!fileName) {


### PR DESCRIPTION
Fixed check for body content to exist and gracefully return errorcode if not
