### PR TITLE
fix: missing iam permission for s3 and html-pdf-ms

### DIFF
--- a/services/html-pdf-ms/serverless.yml
+++ b/services/html-pdf-ms/serverless.yml
@@ -39,6 +39,7 @@ provider:
         - Effect: Allow
           Action:
             - kms:Decrypt
+            - kms:GenerateDataKey
           Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
         - Effect: Allow


### PR DESCRIPTION
To write to an s3 bucket that is encrypted, the kms:GenerateDataKey permission is
needed. This was added to ms-viva ms but were missed in html-pdf-ms

