### PR TITLE
fix: navet-ms needs write access to cert bucket

### DIFF
--- a/services/navet-ms/serverless.yml
+++ b/services/navet-ms/serverless.yml
@@ -31,21 +31,27 @@ provider:
           Action:
             - s3:getObject
           Resource:
-            - "Fn::Join": 
-              - ""
-              - - Fn::ImportValue: ${self:custom.stage}-CertificatesBucketArn
-                - "/*"
+            - 'Fn::Join':
+                - ''
+                - - Fn::ImportValue: ${self:custom.stage}-CertificatesBucketArn
+                  - '/*'
 
         - Effect: Allow
           Action:
             - SSM:GetParameter*
-          Resource: 
-            - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../config.json):${self:custom.stage}.navet.envsKeyName}"
+          Resource:
+            - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../config.json):${self:custom.stage}.navet.envsKeyName}'
 
         - Effect: Allow
           Action:
             - events:PutEvents
-          Resource: "*"
+          Resource: '*'
+
+        - Effect: Allow
+          Action:
+            - kms:Decrypt
+            - kms:GenerateDataKey
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
 functions:
   poll:


### PR DESCRIPTION
When encrypting the s3 bucket, navet-ms was not updated
with the correct permissions

