### PR TITLE
fix: 🐛 issue with expiration time

### DIFF
--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -244,6 +244,8 @@ functions:
           pattern:
             source:
               - casesApi.updateCase
+            detail:
+              state: [{ "anything-but": ["VIVA_RANDOM_CHECK_REQUIRED", "VIVA_COMPLETION_REQUIRED"] }]
       - eventBridge:
           pattern:
             source:


### PR DESCRIPTION
If case is required for completion and the user starts filling in the form. Case status will be set to 'active:ongoing'.

It casued the lambda to trigger and update expiration time based on the wrong status time frame.

This commit fixes it by not trigger on the state VIVA_COMPLETION_REQUIRED or VIVA_RANDOM_CHECK_REQUIRED
