### PR TITLE
feat: implement viva submission queue proxy

### DIFF
--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -20,8 +20,7 @@ const destructRecord = record => {
 };
 
 export async function main(event, context) {
-  log.info(event);
-  const failedRecords = event.Records.map(record => record.messageId);
+  let failedRecords = event.Records.map(record => record.messageId);
 
   const [paramsReadError, vivaCaseSSMParams] = await to(
     params.read(config.cases.providers.viva.envsKeyName)
@@ -42,7 +41,7 @@ export async function main(event, context) {
     const { recurringFormId } = vivaCaseSSMParams;
 
     if (caseItem.currentFormId !== recurringFormId) {
-      failedRecords.shift();
+      failedRecords = failedRecords.filter(itemId => itemId != record.itemId);
       log.info(
         'Current form is not an recurring form',
         context.awsRequestId,
@@ -119,7 +118,7 @@ export async function main(event, context) {
       );
       continue;
     }
-    failedRecords.shift();
+    failedRecords = failedRecords.filter(itemId => itemId != record.itemId);
   }
   log.info(failedRecords);
   return {

--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -128,10 +128,10 @@ export async function main(event, context) {
       failedRecords = failedRecords.filter(itemId => itemId != record.messageId);
     } catch (ex) {
       log.error(
-        ('Event could not be parsed',
+        'Event could not be parsed',
         context.awsRequestId,
         'service-viva-ms-submitApplication-020',
-        ex)
+        ex
       );
     }
   }

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -143,7 +143,7 @@ functions:
     timeout: 15
     events:
       - sqs:
-          arn: !ImportValue ${self:custom.stage}-VivaSubmissionQueue
+          arn: !ImportValue ${self:custom.stage}-VivaSubmissionQueueArn
           batchSize: 1
           functionResponseType: ReportBatchItemFailures
 

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -183,9 +183,7 @@ functions:
             detail:
               status:
                 type: [{ 'prefix': 'active:submitted' }]
-              state:
-                - VIVA_RANDOM_CHECK_REQUIRED
-                - VIVA_COMPLETION_REQUIRED
+              state: ['VIVA_RANDOM_CHECK_REQUIRED', 'VIVA_COMPLETION_REQUIRED']
 
   syncOfficers:
     handler: lambdas/syncOfficers.main
@@ -232,6 +230,9 @@ functions:
           pattern:
             source:
               - casesApi.updateCase
+            detail:
+              state:
+                [{ 'anything-but': ['VIVA_RANDOM_CHECK_REQUIRED', 'VIVA_COMPLETION_REQUIRED'] }]
       - eventBridge:
           pattern:
             source:

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -145,7 +145,6 @@ functions:
       - sqs:
           arn: !ImportValue ${self:custom.stage}-VivaSubmissionQueueArn
           batchSize: 1
-          functionResponseType: ReportBatchItemFailures
 
   checkCompletionsStatus:
     handler: lambdas/checkCompletionsStatus.main

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -230,9 +230,6 @@ functions:
           pattern:
             source:
               - casesApi.updateCase
-            detail:
-              state:
-                [{ 'anything-but': ['VIVA_RANDOM_CHECK_REQUIRED', 'VIVA_COMPLETION_REQUIRED'] }]
       - eventBridge:
           pattern:
             source:

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -145,6 +145,7 @@ functions:
       - sqs:
           arn: !ImportValue ${self:custom.stage}-VivaSubmissionQueue
           batchSize: 1
+          functionResponseType: ReportBatchItemFailures
 
   checkCompletionsStatus:
     handler: lambdas/checkCompletionsStatus.main

--- a/services/viva-ms/serverless.yml
+++ b/services/viva-ms/serverless.yml
@@ -34,13 +34,13 @@ provider:
           Action:
             - SSM:GetParameter*
           Resource:
-            - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../config.json):${self:custom.stage}.vada.envsKeyName}"
-            - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../config.json):${self:custom.stage}.cases.providers.viva.envsKeyName}"
+            - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../config.json):${self:custom.stage}.vada.envsKeyName}'
+            - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../config.json):${self:custom.stage}.cases.providers.viva.envsKeyName}'
 
         - Effect: Allow
           Action:
             - events:PutEvents
-          Resource: "*"
+          Resource: '*'
 
         - Effect: Allow
           Action:
@@ -49,14 +49,14 @@ provider:
           Resource:
             - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
             - Fn::Join:
-                - ""
+                - ''
                 - - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
-                  - "/*"
+                  - '/*'
             - Fn::ImportValue: ${self:custom.resourcesStage}-PdfStorageBucketArn
             - Fn::Join:
-                - ""
+                - ''
                 - - Fn::ImportValue: ${self:custom.resourcesStage}-PdfStorageBucketArn
-                  - "/*"
+                  - '/*'
 
         - Effect: Allow
           Action:
@@ -65,21 +65,21 @@ provider:
             - dynamodb:Query
             - dynamodb:GetItem
           Resource:
-            - "Fn::ImportValue": ${self:custom.resourcesStage}-CasesTableArn
+            - 'Fn::ImportValue': ${self:custom.resourcesStage}-CasesTableArn
 
         - Effect: Allow
           Action:
             - dynamodb:Query
             - dynamodb:GetItem
           Resource:
-            - "Fn::ImportValue": ${self:custom.resourcesStage}-UsersTableArn
+            - 'Fn::ImportValue': ${self:custom.resourcesStage}-UsersTableArn
 
         - Effect: Allow
           Action:
             - dynamodb:Query
             - dynamodb:GetItem
           Resource:
-            - "Fn::ImportValue": ${self:custom.resourcesStage}-FormsTableArn
+            - 'Fn::ImportValue': ${self:custom.resourcesStage}-FormsTableArn
 
         - Effect: Allow
           Action:
@@ -142,23 +142,9 @@ functions:
     handler: lambdas/submitApplication.main
     timeout: 15
     events:
-      - eventBridge:
-          pattern:
-            source:
-              - cases.database
-            detail-type:
-              - MODIFY
-            detail:
-              dynamodb:
-                NewImage:
-                  provider:
-                    S: ["VIVA"]
-                  status:
-                    M:
-                      type:
-                        S: [{ "prefix": "active:submitted" }]
-                  state:
-                    S: ["PDF_GENERATED"]
+      - sqs:
+          arn: !ImportValue ${self:custom.stage}-VivaSubmissionQueue
+          batchSize: 1
 
   checkCompletionsStatus:
     handler: lambdas/checkCompletionsStatus.main
@@ -196,7 +182,7 @@ functions:
               - casesApiUpdateCaseSuccess
             detail:
               status:
-                type: [{ "prefix": "active:submitted" }]
+                type: [{ 'prefix': 'active:submitted' }]
               state:
                 - VIVA_RANDOM_CHECK_REQUIRED
                 - VIVA_COMPLETION_REQUIRED
@@ -216,7 +202,7 @@ functions:
               dynamodb:
                 NewImage:
                   provider:
-                    S: ["VIVA"]
+                    S: ['VIVA']
 
   syncWorkflow:
     handler: lambdas/syncWorkflow.main
@@ -268,5 +254,5 @@ functions:
               - casesApiUpdateCaseSuccess
             detail:
               status:
-                type: [{ "prefix": "active:submitted" }]
-              state: ["VIVA_CASE_CREATED"]
+                type: [{ 'prefix': 'active:submitted' }]
+              state: ['VIVA_CASE_CREATED']


### PR DESCRIPTION
## Purpose
NOTE: This PR is depending on: https://github.com/helsingborg-stad/helsingborg-io-sls-resources/pull/94

When sending an application to Viva, the request sometimes fails due to instability. To work around this shortcoming and avoid manual labour to correct applications, each application is added to an SQS queue when the state has reached PDF_GENERATED. The queue has a lambda trigger that executes submitApplication on regular basis until the application has been successfully submitted.

## Flow
When a message is retrieved in the queue, the lambda submitApplication is executed with an event of type:
https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

Lambda is processing the event in the same way as before with the following exceptions:
1. The input event can consist of multiple queued applications
2. The return value is a list of id's of applications that should be returned to queue and retried due to viva not responding.

Retries are initially set to 30 seconds. Queue items will be deleted after 4 days of failure.