### PR TITLE
fix: remove forgotten babel config in cases-api

### DIFF
--- a/services/cases-api/babel.config.js
+++ b/services/cases-api/babel.config.js
@@ -1,5 +1,0 @@
-const babelBase = require('../../babel-base.config');
-
-module.exports = {
-  ...babelBase,
-};

--- a/services/cases-api/package.json
+++ b/services/cases-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ../../node_modules/.bin/jest"
+    "test": "cd ../../ && node node_modules/.bin/jest cases-api"
   },
   "keywords": [],
   "author": "Helsingborg Stad",


### PR DESCRIPTION
## Explain the changes you’ve made
Removed forgotten babel config in cases-api which caused the pipeline to fail due to missing babel-base-config file.

## Explain why these changes are made
A global babel config is now used for all services instead individual once. 

## How to test
1. Run `yarn test` in root of the repo - all tests should be successful
2. Run `yarn test` in `cases-api` - only `cases-api` tests should be successful 