### PR TITLE
feat: add additional logging to submit application lambda

### DIFF
--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -86,15 +86,14 @@ export async function main(event, context) {
       vivaErrorMessage: vivaPostError.vadaResponse?.error?.details?.errorMessage ?? 'N/A',
       caseId: SK,
     };
-    switch (error.vivaErrorCode) {
-      case '1014':
-        log.warn(
-          'Failed to submit Viva application. Will NOT be retried.',
-          context.awsRequestId,
-          null,
-          error
-        );
-        return true;
+    if (error.vivaErrorCode === '1014') {
+      log.warn(
+        'Failed to submit Viva application. Will NOT be retried.',
+        context.awsRequestId,
+        null,
+        error
+      );
+      return true;
     }
     throw new TraceException(
       'Failed to submit Viva application. Will be retried.',

--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -14,8 +14,9 @@ import vivaAdapter from '../helpers/vivaAdapterRequestClient';
 
 const dynamoDbConverter = AWS.DynamoDB.Converter;
 class TraceException extends Error {
-  constructor(message, customData) {
+  constructor(message, requestId, customData) {
     super(message);
+    this.requestId = requestId;
     this.customData = customData;
   }
 }
@@ -26,20 +27,31 @@ const destructRecord = record => {
 
 export async function main(event, context) {
   if (event.Records.length !== 1) {
-    throw new TraceException(`Lambda received (${event.Records.length}) but expected only one.`);
+    throw new TraceException(
+      `Lambda received (${event.Records.length}) but expected only one.`,
+      context.awsRequestId
+    );
   }
   const [paramsReadError, vivaCaseSSMParams] = await to(
     params.read(config.cases.providers.viva.envsKeyName)
   );
   if (paramsReadError) {
-    throw new TraceException('Read ssm params ´config.cases.providers.viva.envsKeyName´ failed');
+    throw new TraceException(
+      'Read ssm params ´config.cases.providers.viva.envsKeyName´ failed',
+      context.awsRequestId
+    );
   }
   const [record] = event.Records;
   const caseItem = destructRecord(record);
+  const { PK, SK, pdf: pdfBinaryBuffer } = caseItem;
 
-  log.info(
-    `Processing record id: (${record.messageId}), receive-count: (${record.attributes.ApproximateReceiveCount}))`
-  );
+  log.info('Processing record', context.awsRequestId, null, {
+    messageId: record.messageId,
+    receiveCount: record.attributes.ApproximateReceiveCount,
+    firstReceived: record.attributes.ApproximateFirstReceiveTimestamp,
+    visibilityTimeout: record.attributes.VisibilityTimeout,
+    caseId: SK,
+  });
 
   const { recurringFormId } = vivaCaseSSMParams;
 
@@ -52,7 +64,6 @@ export async function main(event, context) {
     return true;
   }
 
-  const { PK, SK, pdf: pdfBinaryBuffer } = caseItem;
   const personalNumber = PK.substring(5);
 
   const [vivaPostError, vivaApplicationResponse] = await to(
@@ -68,22 +79,31 @@ export async function main(event, context) {
 
   if (vivaPostError) {
     const error = {
-      statusCode: vivaPostError.status,
-      recordId: record.messageId,
-      statusMessage: vivaPostError.vadaResponse?.error?.details?.errorMessage ?? '',
-      receiveCount: record.attributes.ApproximateReceiveCount,
+      messageId: record.messageId,
+      httpStatusCode: vivaPostError.status,
+      vivaErrorCode: vivaPostError.vadaResponse?.error?.details?.errorCode ?? 'HTTPS',
+      vivaErrorMessage: vivaPostError.vadaResponse?.error?.details?.errorMessage ?? '',
       caseId: SK,
     };
-    switch (vivaPostError.vadaResponse?.error?.details?.errorCode) {
-      case 1014:
-        log.warn('Failed to submit Viva application', error);
+    switch (error.vivaErrorCode) {
+      case '1014':
+        log.warn(
+          'Failed to submit Viva application. Will NOT be retried.',
+          context.awsRequestId,
+          null,
+          error
+        );
         return true;
     }
-    throw new TraceException('Failed to submit Viva application', error);
+    throw new TraceException(
+      'Failed to submit Viva application. Will be retried.',
+      context.awsRequestId,
+      error
+    );
   }
 
   if (notApplicationReceived(vivaApplicationResponse)) {
-    throw new TraceException('Viva application receive failed', {
+    throw new TraceException('Viva application receive failed', context.awsRequestId, {
       vivaResponse: { ...vivaApplicationResponse },
     });
   }
@@ -91,6 +111,7 @@ export async function main(event, context) {
   if (!vivaApplicationResponse?.id) {
     throw new TraceException(
       'Viva application response does not contain any workflow id',
+      context.awsRequestId,
       vivaApplicationResponse
     );
   }
@@ -98,13 +119,17 @@ export async function main(event, context) {
   const caseKeys = { PK, SK };
   const [updateError] = await to(updateVivaCase(caseKeys, vivaApplicationResponse.id));
   if (updateError) {
-    throw new TraceException('Failed to update Viva case', updateError);
+    throw new TraceException('Failed to update Viva case', context.awsRequestId, updateError);
   }
 
   const clientUser = { personalNumber };
   const [putEventError] = await to(putVivaMsEvent.applicationReceivedSuccess(clientUser));
   if (putEventError) {
-    throw new TraceException('Put event ´applicationReceivedSuccess´ failed', putEventError);
+    throw new TraceException(
+      'Put event ´applicationReceivedSuccess´ failed',
+      context.awsRequestId,
+      putEventError
+    );
   }
   return true;
 }

--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -16,6 +16,7 @@ const dynamoDbConverter = AWS.DynamoDB.Converter;
 class TraceException extends Error {
   constructor(message, requestId, customData) {
     super(message);
+    this.level = 'error';
     this.requestId = requestId;
     this.customData = customData;
   }
@@ -45,7 +46,7 @@ export async function main(event, context) {
   const caseItem = destructRecord(record);
   const { PK, SK, pdf: pdfBinaryBuffer } = caseItem;
 
-  log.info('Processing record', context.awsRequestId, null, {
+  log.info('Processing record', context.awsRequestId, undefined, {
     messageId: record.messageId,
     receiveCount: record.attributes.ApproximateReceiveCount,
     firstReceived: record.attributes.ApproximateFirstReceiveTimestamp,
@@ -81,8 +82,8 @@ export async function main(event, context) {
     const error = {
       messageId: record.messageId,
       httpStatusCode: vivaPostError.status,
-      vivaErrorCode: vivaPostError.vadaResponse?.error?.details?.errorCode ?? 'HTTPS',
-      vivaErrorMessage: vivaPostError.vadaResponse?.error?.details?.errorMessage ?? '',
+      vivaErrorCode: vivaPostError.vadaResponse?.error?.details?.errorCode ?? 'N/A',
+      vivaErrorMessage: vivaPostError.vadaResponse?.error?.details?.errorMessage ?? 'N/A',
       caseId: SK,
     };
     switch (error.vivaErrorCode) {
@@ -131,6 +132,10 @@ export async function main(event, context) {
       putEventError
     );
   }
+  log.info('Record processed SUCCESSFULLY', context.awsRequestId, undefined, {
+    messageId: record.messageId,
+    caseId: SK,
+  });
   return true;
 }
 

--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -67,12 +67,19 @@ export async function main(event, context) {
   );
 
   if (vivaPostError) {
-    throw new TraceException('Failed to submit Viva application', {
-      errorCode: vivaPostError.status,
+    const error = {
+      statusCode: vivaPostError.status,
       recordId: record.messageId,
+      statusMessage: vivaPostError.vadaResponse?.error?.details?.errorMessage ?? '',
       receiveCount: record.attributes.ApproximateReceiveCount,
       caseId: SK,
-    });
+    };
+    switch (vivaPostError.vadaResponse?.error?.details?.errorCode) {
+      case 1014:
+        log.warn('Failed to submit Viva application', error);
+        return true;
+    }
+    throw new TraceException('Failed to submit Viva application', error);
   }
 
   if (notApplicationReceived(vivaApplicationResponse)) {

--- a/services/viva-ms/lambdas/submitApplication.js
+++ b/services/viva-ms/lambdas/submitApplication.js
@@ -68,7 +68,10 @@ export async function main(event, context) {
 
   if (vivaPostError) {
     throw new TraceException('Failed to submit Viva application', {
-      axios: { ...vivaPostError },
+      errorCode: vivaPostError.status,
+      recordId: record.messageId,
+      receiveCount: record.attributes.ApproximateReceiveCount,
+      caseId: SK,
     });
   }
 


### PR DESCRIPTION
To be able to do a proper logging, some more data is needed to filter
on individual cases.

This change will log the following structure:

**When an error removes a case from the queue**
```
{
    "requestId": "42121af7-8843-5a0f-9025-40720878a8e9"
    "message": "Failed to submit Viva application. Will NOT be retried.",
    "level": "warn",
    "customData": {
        "caseId": "CASE#ZZZ",
        "httpStatusCode": 503,
        "messageId": "cf1aa452-f8ba-45bb-8a26-d6806cffc46b",
        "vivaErrorCode": "1014",
        "vivaErrorMessage": "Status (896) tillåter inte inlämnande av fortsatt ansökan."
    },
}
```

**When a failed message issues retries**
```
  {
    "requestId": "43859057-7ec7-57d4-8669-cad2f71a1dc2",
    "errorMessage": "Failed to submit Viva application. Will be retried.",
    "level": "error",
    "errorType": "Error",
    "customData": {
        "messageId": "328f240f-0eb8-458a-bd96-5ea5be48beea",
        "vivaErrorCode": "N/A",
        "vivaErrorMessage": "N/A",
        "caseId": "CASE#7bf67325-c1f7-45b7-b0c0-8370cec96d98"
    }
```