### PR TITLE
fix: bankid sign and cancel does not work

### DIFF
--- a/services/bankid-api/src/lambdas/cancel.ts
+++ b/services/bankid-api/src/lambdas/cancel.ts
@@ -48,7 +48,7 @@ export const main = async (event: { body: string }, context: { awsRequestId: str
 async function sendBankIdCancelRequest(
   params: BankIdParams,
   payload: BankIdCancelLambdaRequest
-): Promise<BankIdCancelResponse> {
+): Promise<BankIdCancelResponse | undefined> {
   const [, bankIdClientResponse] = await to(bankId.client(params));
   if (!bankIdClientResponse) throwError(503);
 

--- a/services/bankid-api/src/lambdas/cancel.ts
+++ b/services/bankid-api/src/lambdas/cancel.ts
@@ -14,7 +14,9 @@ interface BankIdCancelLambdaRequest {
   orderRef: string;
 }
 
-type BankIdCancelResponse = Record<string, never> | undefined;
+interface BankIdCancelResponse {
+  data?: Record<string, never>;
+}
 
 export const main = async (event: { body: string }, context: { awsRequestId: string }) => {
   const { orderRef } = JSON.parse(event.body);
@@ -35,8 +37,11 @@ export const main = async (event: { body: string }, context: { awsRequestId: str
     return response.failure(error);
   }
 
+  const attributes = bankIdCancelResponse.data ? bankIdCancelResponse.data : {};
+
   return response.success(200, {
     type: 'bankidCancel',
+    attributes,
   });
 };
 

--- a/services/bankid-api/src/lambdas/sign.ts
+++ b/services/bankid-api/src/lambdas/sign.ts
@@ -20,10 +20,12 @@ interface BankIdSignLambdaRequest {
 }
 
 interface BankIdSignResponse {
-  orderRef: string;
-  autoStartToken: string;
-  qrStartToken: string;
-  qrStartSecret: string;
+  data?: {
+    orderRef: string;
+    autoStartToken: string;
+    qrStartToken: string;
+    qrStartSecret: string;
+  };
 }
 
 export const main = async (event: { body: string }, context: { awsRequestId: string }) => {
@@ -65,9 +67,11 @@ export const main = async (event: { body: string }, context: { awsRequestId: str
 
     return failure(error);
   }
+  const attributes = bankIdSignResponse.data ? bankIdSignResponse.data : {};
 
   return success(200, {
     type: 'bankIdSign',
+    attributes,
   });
 };
 // Not validating personalNumber as it is an optional Parameter


### PR DESCRIPTION
attributes not provided to app anymore after refactoring.

Previously, a property named attributes was provided in the response. This property is not coming anymore.

