### PR TITLE
fix: change commonjs to es6 for typescript compiler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2021",
     "moduleResolution": "node",
-    "module": "CommonJS",
+    "module": "es6",
     "types": ["node", "jest"],
     "typeRoots": ["node_modules/@types"],
     "allowJs": true,


### PR DESCRIPTION
To avoid warnings when issuing sls deploy tith typescript projects
the commonjs flag is replaced with es6

