### PR TITLE
feat: change name of filenames in attachment upload

### DIFF
--- a/libs/token.d.ts
+++ b/libs/token.d.ts
@@ -1,9 +1,13 @@
+export interface Token {
+  personalNumber: string;
+}
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Takes an http event with an jwt authorization header, and returns the decoded info from it. Does not check if the token is valid, that should be handled by an authorizer.
  * @param {*} httpEvent the event passed to the lambda
  */
-export function decodeToken(httpEvent: any): any;
+export function decodeToken(httpEvent: any): Token;
 /**
  * Asynchronously sign a given payload into a JSON Web Token.
  * @param {obj} jsonToSign the payload of the json web token.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "main": "index.js",
   "dependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.16.5",
-    "@helsingborg-stad/npm-api-error-handling": "^0.15.0",
+    "@helsingborg-stad/npm-api-error-handling": "^0.15.1",
     "await-to-js": "^2.1.1",
     "aws-sdk": "^2.1048.0",
     "axios": "^0.24.0",
@@ -73,6 +73,7 @@
     "joi": "^17.5.0",
     "puppeteer-core": "^10.4.0",
     "uuid": "^3.3.2",
+    "uuidv4": "^6.2.12",
     "winston": "^3.3.3"
   },
   "config": {

--- a/services/users-api/package.json
+++ b/services/users-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd ../../ && node node_modules/.bin/jest users-api"
   },
   "keywords": [],
   "author": "Helsingborg Stad",

--- a/services/users-api/src/helpers/files.ts
+++ b/services/users-api/src/helpers/files.ts
@@ -1,17 +1,12 @@
-import { uuid } from 'uuidv4';
-
 type UUIDGenerator = () => string;
 
-export function getUniqueFileName(
-  fileName: string,
-  separator = '_',
-  uuidGenerator: UUIDGenerator = uuid
-) {
+export function getUniqueFileName(fileName: string, separator = '_', uuidGenerator: UUIDGenerator) {
   const lastIndex = fileName.lastIndexOf('.');
+  const uuid = uuidGenerator();
 
   if (-1 === lastIndex) {
-    return `${fileName}${separator}${uuidGenerator()}`;
+    return `${fileName}${separator}${uuid}`;
   }
-  const [name, ext] = [fileName.slice(0, lastIndex), fileName.slice(lastIndex)];
-  return `${name}${separator}${uuidGenerator()}${ext}`;
+  const [name, extension] = [fileName.slice(0, lastIndex), fileName.slice(lastIndex)];
+  return `${name}${separator}${uuid}${extension}`;
 }

--- a/services/users-api/src/helpers/files.ts
+++ b/services/users-api/src/helpers/files.ts
@@ -1,0 +1,17 @@
+import { uuid } from 'uuidv4';
+
+type UUIDGenerator = () => string;
+
+export function getUniqueFileName(
+  fileName: string,
+  separator = '_',
+  uuidGenerator: UUIDGenerator = uuid
+) {
+  const lastIndex = fileName.lastIndexOf('.');
+
+  if (-1 === lastIndex) {
+    return `${fileName}${separator}${uuidGenerator()}`;
+  }
+  const [name, ext] = [fileName.slice(0, lastIndex), fileName.slice(lastIndex)];
+  return `${name}${separator}${uuidGenerator()}${ext}`;
+}

--- a/services/users-api/src/lambdas/uploadAttachment.ts
+++ b/services/users-api/src/lambdas/uploadAttachment.ts
@@ -1,32 +1,69 @@
 import to from 'await-to-js';
-import { v4 as uuid } from 'uuid';
 import S3 from '../libs/S3';
 import * as response from '../libs/response';
 import { BadRequestError } from '@helsingborg-stad/npm-api-error-handling';
-import { decodeToken } from '../libs/token';
+import { decodeToken, Token } from '../libs/token';
 import log from '../libs/logs';
+import { getUniqueFileName } from '../helpers/files';
+
+export interface UploadAttachmentRequest {
+  fileName?: string;
+  mime?: string;
+}
+
+export interface LambdaContext {
+  decodeToken: (event: AWSEvent) => Token;
+  getUniqueFileName: (name: string) => string;
+  getSignedUrl: (
+    bucketName?: string,
+    method?: string,
+    params?: Record<string, unknown>
+  ) => Promise<string>;
+}
+
+export interface AWSEvent {
+  body?: string;
+  headers?: {
+    Authorization?: string;
+  };
+}
+
+export interface AWSContext {
+  awsRequestId: string;
+}
 
 // File formats that we accept.
 const allowedMimes = ['image/jpeg', 'image/png', 'image/jpg', 'application/pdf'];
 
+export async function main(event: AWSEvent, awsContext: AWSContext) {
+  return await lambda(event, awsContext, {
+    decodeToken,
+    getUniqueFileName,
+    getSignedUrl: S3.getSignedUrl,
+  });
+}
 /**
  * Get the user with the personal number specified in the path
  */
-export async function main(event, context) {
-  const decodedToken = decodeToken(event);
+export async function lambda(
+  event: AWSEvent,
+  awsContext: AWSContext,
+  lambdaContext: LambdaContext
+) {
+  const decodedToken = lambdaContext.decodeToken(event);
 
   if (!event?.body) {
     const errorMessage = 'Body data is missing in request';
-    log.error(errorMessage, context.awsRequestId, 'service-users-api-uploadAttachment-000');
+    log.error(errorMessage, awsContext.awsRequestId, 'service-users-api-uploadAttachment-000');
     return response.failure(new BadRequestError(errorMessage));
   }
 
-  const { fileName, mime } = JSON.parse(event.body);
+  const { fileName, mime } = JSON.parse(event.body) as UploadAttachmentRequest;
 
   if (!fileName) {
     // Check if fileName exsits in event body
     const errorMessage = 'Could not find key "fileName" in request body';
-    log.error(errorMessage, context.awsRequestId, 'service-users-api-uploadAttachment-001');
+    log.error(errorMessage, awsContext.awsRequestId, 'service-users-api-uploadAttachment-001');
 
     return response.failure(new BadRequestError(errorMessage));
   }
@@ -34,7 +71,7 @@ export async function main(event, context) {
   if (!mime) {
     // Check if mimeType exists in event body.
     const errorMessage = 'Could not find key "mime" in request body';
-    log.error(errorMessage, context.awsRequestId, 'service-users-api-uploadAttachment-002');
+    log.error(errorMessage, awsContext.awsRequestId, 'service-users-api-uploadAttachment-002');
 
     return response.failure(new BadRequestError());
   }
@@ -42,13 +79,13 @@ export async function main(event, context) {
   if (!allowedMimes.includes(mime)) {
     // Check if passed mimeType is a fileformat that we allow.
     const errorMessage = `The mimeType ${mime} is not allowed`;
-    log.error(errorMessage, context.awsRequestId, 'service-users-api-uploadAttachment-003');
+    log.error(errorMessage, awsContext.awsRequestId, 'service-users-api-uploadAttachment-003');
 
     return response.failure(new BadRequestError(errorMessage));
   }
 
   // The path to where we want to upload a file in the s3 bucket.
-  const s3FileName = `${uuid()}_${fileName}`;
+  const s3FileName = lambdaContext.getUniqueFileName(fileName);
   const s3Key = `${decodedToken.personalNumber}/${s3FileName}`;
 
   // TODO: Check if we can set a file size limit in these params.
@@ -61,13 +98,13 @@ export async function main(event, context) {
 
   // Request pre signed upload url from aws s3.
   const [error, uploadUrl] = await to(
-    S3.getSignedUrl(process.env.BUCKET_NAME, 'putObject', params)
+    lambdaContext.getSignedUrl(process.env.BUCKET_NAME, 'putObject', params)
   );
 
   if (error) {
     log.error(
       'Get signed url error',
-      context.awsRequestId,
+      awsContext.awsRequestId,
       'service-users-api-uploadAttachment-003'
     );
 

--- a/services/users-api/test/files.test.ts
+++ b/services/users-api/test/files.test.ts
@@ -1,0 +1,14 @@
+import { getUniqueFileName } from '../src/helpers/files';
+
+it('Multiple dots only treating the last one as extension', async () => {
+  expect(getUniqueFileName('my.file.jpg', '_', () => 'my:uuid')).toBe('my.file_my:uuid.jpg');
+});
+it('Handle filename without extension', async () => {
+  expect(getUniqueFileName('myfile', '_', () => 'my:uuid')).toBe('myfile_my:uuid');
+});
+it('Handle comon case name with extension', async () => {
+  expect(getUniqueFileName('myfile.jpg', '_', () => 'my:uuid')).toBe('myfile_my:uuid.jpg');
+});
+it('Handle empty filename', async () => {
+  expect(getUniqueFileName('', '_', () => 'my:uuid')).toBe('_my:uuid');
+});

--- a/services/users-api/test/files.test.ts
+++ b/services/users-api/test/files.test.ts
@@ -1,14 +1,23 @@
 import { getUniqueFileName } from '../src/helpers/files';
 
-it('Multiple dots only treating the last one as extension', async () => {
-  expect(getUniqueFileName('my.file.jpg', '_', () => 'my:uuid')).toBe('my.file_my:uuid.jpg');
+const uuid = 'my:uuid';
+
+test('when multiple dots exists in a filename, only the last one as extension', () => {
+  const result = getUniqueFileName('my.file.jpg', '_', () => uuid);
+  expect(result).toBe('my.file_my:uuid.jpg');
 });
-it('Handle filename without extension', async () => {
-  expect(getUniqueFileName('myfile', '_', () => 'my:uuid')).toBe('myfile_my:uuid');
+
+test('filename without extension should be formatted properly', () => {
+  const result = getUniqueFileName('myfile', '_', () => uuid);
+  expect(result).toBe('myfile_my:uuid');
 });
-it('Handle comon case name with extension', async () => {
-  expect(getUniqueFileName('myfile.jpg', '_', () => 'my:uuid')).toBe('myfile_my:uuid.jpg');
+
+test('common filename with extension should be formatted properly', () => {
+  const result = getUniqueFileName('myfile.jpg', '_', () => uuid);
+  expect(result).toBe('myfile_my:uuid.jpg');
 });
-it('Handle empty filename', async () => {
-  expect(getUniqueFileName('', '_', () => 'my:uuid')).toBe('_my:uuid');
+
+test('empty filename should be handled gracefully', () => {
+  const result = getUniqueFileName('', '_', () => uuid);
+  expect(result).toBe('_my:uuid');
 });

--- a/services/users-api/test/uploadAttachment.test.ts
+++ b/services/users-api/test/uploadAttachment.test.ts
@@ -1,0 +1,98 @@
+import { lambda, LambdaContext } from '../src/lambdas/uploadAttachment';
+
+const abstractLambdaContext: LambdaContext = {
+  decodeToken: () => ({
+    personalNumber: 'my:decoded:token',
+  }),
+  getSignedUrl: () => Promise.resolve('my:signed:url'),
+  getUniqueFileName: () => 'myfile_00000000-0000-0000-0000-000000000000.jpg',
+};
+
+const abstractAWSContext = {
+  awsRequestId: 'my:request:id',
+};
+
+const abstractAWSEvent = {
+  body: JSON.stringify({
+    fileName: 'myfile.jpg',
+    mime: 'image/jpeg',
+  }),
+  headers: {
+    Authorization: 'Bearer 01234567890',
+  },
+};
+
+it('Successful Request', async () => {
+  const result = await lambda(abstractAWSEvent, abstractAWSContext, abstractLambdaContext);
+
+  expect(result.statusCode).toBe(200);
+
+  expect(JSON.parse(result.body)).toEqual({
+    jsonapi: {
+      version: '1.0',
+    },
+    data: {
+      type: 'userAttachment',
+      attributes: {
+        uploadUrl: 'my:signed:url',
+        fileName: 'myfile_00000000-0000-0000-0000-000000000000.jpg',
+      },
+    },
+  });
+});
+
+it('Event body is missing', async () => {
+  const result = await lambda({}, abstractAWSContext, abstractLambdaContext);
+  expect(result.statusCode).toBe(400);
+});
+
+it('FileName is missing in request payload', async () => {
+  const result = await lambda(
+    {
+      body: JSON.stringify({
+        mime: 'image/jpg',
+      }),
+    },
+    abstractAWSContext,
+    abstractLambdaContext
+  );
+  expect(result.statusCode).toBe(400);
+});
+
+it('MimeType is missing in request payload', async () => {
+  const result = await lambda(
+    {
+      body: JSON.stringify({
+        fileName: 'myfile.jpg',
+      }),
+    },
+    abstractAWSContext,
+    abstractLambdaContext
+  );
+  expect(result.statusCode).toBe(400);
+});
+
+it('MimeType is unknown in request payload', async () => {
+  const result = await lambda(
+    {
+      body: JSON.stringify({
+        fileName: 'myfile.jpg',
+        mime: 'my/mime-type',
+      }),
+    },
+    abstractAWSContext,
+    abstractLambdaContext
+  );
+  expect(result.statusCode).toBe(400);
+});
+
+it('FAILED to retreive signed URL', async () => {
+  const result = await lambda(abstractAWSEvent, abstractAWSContext, {
+    ...abstractLambdaContext,
+    getSignedUrl: () =>
+      Promise.reject({
+        status: 400,
+      }),
+  });
+  expect(result.statusCode).toBe(400);
+});

--- a/services/users-api/test/uploadAttachment.test.ts
+++ b/services/users-api/test/uploadAttachment.test.ts
@@ -22,11 +22,10 @@ const abstractAWSEvent = {
   },
 };
 
-it('Successful Request', async () => {
+test('successful request should return expected structure', async () => {
   const result = await lambda(abstractAWSEvent, abstractAWSContext, abstractLambdaContext);
 
   expect(result.statusCode).toBe(200);
-
   expect(JSON.parse(result.body)).toEqual({
     jsonapi: {
       version: '1.0',
@@ -41,12 +40,12 @@ it('Successful Request', async () => {
   });
 });
 
-it('Event body is missing', async () => {
+test('event body missing should return status 400', async () => {
   const result = await lambda({}, abstractAWSContext, abstractLambdaContext);
   expect(result.statusCode).toBe(400);
 });
 
-it('FileName is missing in request payload', async () => {
+test('fileName missing should return status 400', async () => {
   const result = await lambda(
     {
       body: JSON.stringify({
@@ -56,10 +55,11 @@ it('FileName is missing in request payload', async () => {
     abstractAWSContext,
     abstractLambdaContext
   );
+
   expect(result.statusCode).toBe(400);
 });
 
-it('MimeType is missing in request payload', async () => {
+test('mimeType missing should return 400', async () => {
   const result = await lambda(
     {
       body: JSON.stringify({
@@ -69,10 +69,11 @@ it('MimeType is missing in request payload', async () => {
     abstractAWSContext,
     abstractLambdaContext
   );
+
   expect(result.statusCode).toBe(400);
 });
 
-it('MimeType is unknown in request payload', async () => {
+test('mimeType unknown should return 400', async () => {
   const result = await lambda(
     {
       body: JSON.stringify({
@@ -83,10 +84,11 @@ it('MimeType is unknown in request payload', async () => {
     abstractAWSContext,
     abstractLambdaContext
   );
+
   expect(result.statusCode).toBe(400);
 });
 
-it('FAILED to retreive signed URL', async () => {
+test('failure to retreive signed URL should return 400', async () => {
   const result = await lambda(abstractAWSEvent, abstractAWSContext, {
     ...abstractLambdaContext,
     getSignedUrl: () =>
@@ -94,5 +96,24 @@ it('FAILED to retreive signed URL', async () => {
         status: 400,
       }),
   });
+
   expect(result.statusCode).toBe(400);
+});
+
+test('signed URL is called with the correct parameters', async () => {
+  const getSignedUrl = jest.fn().mockResolvedValue('');
+
+  await lambda(abstractAWSEvent, abstractAWSContext, {
+    ...abstractLambdaContext,
+    getSignedUrl,
+  });
+
+  expect(getSignedUrl).toHaveBeenCalledWith(
+    undefined,
+    expect.anything(),
+    expect.objectContaining({
+      ContentType: 'image/jpeg',
+      Key: 'my:decoded:token/myfile_00000000-0000-0000-0000-000000000000.jpg',
+    })
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,10 +1476,10 @@
     "@hapi/bourne" "2.x.x"
     "@hapi/hoek" "9.x.x"
 
-"@helsingborg-stad/npm-api-error-handling@^0.15.0":
-  version "0.15.0"
-  resolved "https://npm.pkg.github.com/download/@helsingborg-stad/npm-api-error-handling/0.15.0/3b93f2a68cb1699669fc00ef1580041f2f313c970819898a10a3795ef187802b#8216c00fc0c5b29e442b4861c8db44b58647f22b"
-  integrity sha512-fKBCjFufWnALvASCDNCZuOSu67yjvx3MAUhfa8cHjrLz0t7VTbQXgSRl5pLf6DgoyBadI3319356rUA6wowTuw==
+"@helsingborg-stad/npm-api-error-handling@^0.15.1":
+  version "0.15.1"
+  resolved "https://npm.pkg.github.com/download/@helsingborg-stad/npm-api-error-handling/0.15.1/51db06a67389c74b3962774644fae0226db93c1a3ff5f786e83cbf7d6eb6eee4#8552c67fcb4bc9aa785e176b1e6232ed2e93e7d8"
+  integrity sha512-zUVm9Pp7rCL9D9CB0HXBrbxOnLDXiSM0FUUy0PmLKn6Po86BfQDXF6XorI4NICzj5pnIT46yiJXyZRjZEEsSSg==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -2124,6 +2124,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/uuid@8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
+  integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -9883,15 +9888,23 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+uuid@8.3.2, uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuidv4@^6.2.12:
+  version "6.2.12"
+  resolved "https://registry.yarnpkg.com/uuidv4/-/uuidv4-6.2.12.tgz#e8c1d1d733c3fa4963d4610b8a3a09b4ec58ca96"
+  integrity sha512-UnN4ThIYWhv3ZUE8UwDnnCvh4JafCNu+sQkxmLyjCVwK3rjLfkg3DYiEv6oCMDIAIVEDP4INg4kX/C5hKaRzZA==
+  dependencies:
+    "@types/uuid" "8.3.1"
+    uuid "8.3.2"
 
 v8-compile-cache-lib@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Instead of prefixing the uuid to the filename, it is now inserted before the file extension

Test by verifying the filename(s) as they appear in S3 or Viva
