### PR TITLE
fix: revert tsconfig setting

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2021",
     "moduleResolution": "node",
-    "module": "es6",
+    "module": "CommonJS",
     "types": ["node", "jest"],
     "typeRoots": ["node_modules/@types"],
     "allowJs": true,


### PR DESCRIPTION
The setting module=es6 did not work with local debugging as es6 requires file-extensions
in import statements.
