### PR TITLE
Feat/update error messages

### DIFF
--- a/services/booking-api/src/helpers/strings.ts
+++ b/services/booking-api/src/helpers/strings.ts
@@ -1,0 +1,11 @@
+export default {
+  booking: {
+    create: {
+      missingRequiredParamter:
+        'En eller flera obligatoriska fält saknas för att kunna genomföra bokningen',
+      startTimePassed: 'En boknings starttid kan inte ha passerat',
+      timespanNotExisting: 'Inga bokningar kan skapas inom givet tidsintervall',
+      timeslotNotAvailable: 'Tidsintervallet ej tillgängligt för bokning',
+    },
+  },
+};

--- a/services/booking-api/test/lambdas/create.test.ts
+++ b/services/booking-api/test/lambdas/create.test.ts
@@ -7,6 +7,7 @@ import { BookingRequest, BookingSearchResponse } from '../../src/helpers/types';
 import { isTimeslotTaken } from '../../src/helpers/isTimeslotTaken';
 import { areAllAttendeesAvailable } from '../../src/helpers/timeSpanHelper';
 import { GetTimeSpansResponse } from './../../src/helpers/types';
+import strings from './../../src/helpers/strings';
 
 jest.mock('../../src/helpers/booking');
 jest.mock('../../src/helpers/isTimeslotTaken');
@@ -222,13 +223,14 @@ it('returns error when required parameters does not exists in event', async () =
     body: JSON.stringify({
       jsonapi: { version: '1.0' },
       data: {
-        status: '403',
-        code: '403',
+        status: '400',
+        code: '400',
+        detail: strings.booking.create.missingRequiredParamter,
         message: errorMessage,
       },
     }),
     headers: mockHeaders,
-    statusCode: 403,
+    statusCode: 400,
   };
 
   const result = await main({ body }, mockContext);
@@ -244,13 +246,14 @@ it('returns error when required parameters does not exists in event', async () =
 it('returns failure when timespan does not exist', async () => {
   expect.assertions(6);
 
-  const statusCode = 403;
+  const statusCode = 400;
   const expectedResult = {
     body: JSON.stringify({
       jsonapi: { version: '1.0' },
       data: {
-        status: '403',
-        code: '403',
+        status: '400',
+        code: '400',
+        detail: strings.booking.create.timespanNotExisting,
         message: 'No timeslot exists in the given interval',
       },
     }),
@@ -279,13 +282,14 @@ it('returns error if startTime is in the passed', async () => {
     body: JSON.stringify({
       jsonapi: { version: '1.0' },
       data: {
-        status: '403',
-        code: '403',
+        status: '400',
+        code: '400',
+        detail: strings.booking.create.startTimePassed,
         message: 'Parameter "startTime" cannot be set to a passed value',
       },
     }),
     headers: mockHeaders,
-    statusCode: 403,
+    statusCode: 400,
   };
 
   const result = await main(mockEvent, mockContext);
@@ -317,13 +321,14 @@ it('returns failure when timeslot is already taken', async () => {
     },
   };
 
-  const statusCode = 403;
+  const statusCode = 400;
   const expectedResult = {
     body: JSON.stringify({
       jsonapi: { version: '1.0' },
       data: {
-        status: '403',
-        code: '403',
+        status: '400',
+        code: '400',
+        detail: strings.booking.create.timeslotNotAvailable,
         message: 'Timeslot not available for booking',
       },
     }),


### PR DESCRIPTION
## Explain the changes you’ve made

Added error messages specifically for clients when running the `create` lambda

Good example:
The new error message will be put into the `detail` property in the json-api response.

## Explain why these changes are made
We want to display more user friendly error messages in the client without saving the error messages in the client code.

## Explain your solution
Added new strings file in booking-api which contains the more human readable error messages

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service x`
3. run the create lambda function in postman

## Tested environments

- [x] Your personal AWS environment.
- [x] Your local Serverless environment.
