### PR TITLE
feat: allow winston to log to vscode console

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
       "name": "Launch file",
       "skipFiles": ["<node_internals>/**"],
       "program": "${file}",
-      "envFile": "${workspaceFolder}/.env"
+      "envFile": "${workspaceFolder}/.env",
+      "outputCapture": "std"
     }
   ]
 }


### PR DESCRIPTION
While debugging locally, log outputs from winston are suppressed.
This setting will make the output available in the debug console

