### PR TITLE
fix: increased timout for booking create lambda function

### DIFF
--- a/services/booking-api/serverless.yml
+++ b/services/booking-api/serverless.yml
@@ -41,6 +41,7 @@ provider:
 
 functions:
   createBooking:
+    timeout: 15
     handler: src/lambdas/create.main
     events:
       - http:


### PR DESCRIPTION
## Explain the changes you’ve made

Increased timout value to 15s for booking create lambda function.

## Explain why these changes are made

Sometimes the `booking/create` function exceeds the default timeout limit (6 sec).

## Explain your solution

N/A

## How to test

N/A

## Tested environments

- [] Your personal AWS environment.
- [] Your local Serverless environment.

## Screenshots

N/A

## Other notes

N/A