### PR TITLE
feat: add extended auto logging

### DIFF
--- a/libs/logs.d.ts
+++ b/libs/logs.d.ts
@@ -1,13 +1,52 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export default log;
+type Primitive = string | number;
+type LambdaHandler = (event: any, context: any, callback?: any) => Promise<unknown>;
+type Level = 'info' | 'error' | 'warn' | 'verbose' | 'debug';
 
-type LambdaHandler = (event: any, context: any, callback?: any) => Promise<any>;
 declare namespace log {
-  function log(level: any, message: any, requestId: any, errorCode: any, customData?: any): void;
-  function error(message: any, requestId: any, errorCode: any, customData?: any): void;
-  function warn(message: any, requestId: any, errorCode: any, customData?: any): void;
-  function info(message: any, requestId: any, errorCode: any, customData?: any): void;
-  function verbose(message: any, requestId: any, errorCode: any, customData?: any): void;
-  function debug(message: any, requestId: any, errorCode: any, customData?: any): void;
+  function writeLog(level: Level, message: string, customData?: unknown): void;
+  function writeError(message: string, customData?: unknown): void;
+  function writeWarn(message: string, customData?: unknown): void;
+  function writeInfo(message: string, customData?: unknown): void;
+  function writeVerbose(message: string, customData?: unknown): void;
+  function writeDebug(message: string, customData?: unknown): void;
+  function log(
+    level: Level,
+    message: string,
+    requestId: string,
+    errorCode: Primitive,
+    customData?: unknown
+  ): void;
+  function error(
+    message: string,
+    requestId: string,
+    errorCode: Primitive,
+    customData?: unknown
+  ): void;
+  function warn(
+    message: string,
+    requestId: string,
+    errorCode: Primitive,
+    customData?: unknown
+  ): void;
+  function info(
+    message: string,
+    requestId: string,
+    errorCode: Primitive,
+    customData?: unknown
+  ): void;
+  function verbose(
+    message: string,
+    requestId: string,
+    errorCode: Primitive,
+    customData?: unknown
+  ): void;
+  function debug(
+    message: string,
+    requestId: string,
+    errorCode: Primitive,
+    customData?: unknown
+  ): void;
   function wrap(lambdaHandler: LambdaHandler): LambdaHandler;
 }

--- a/libs/logs.d.ts
+++ b/libs/logs.d.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export default log;
+
+type LambdaHandler = (event: any, context: any, callback?: any) => Promise<any>;
 declare namespace log {
   function log(level: any, message: any, requestId: any, errorCode: any, customData?: any): void;
   function error(message: any, requestId: any, errorCode: any, customData?: any): void;
@@ -7,4 +9,5 @@ declare namespace log {
   function info(message: any, requestId: any, errorCode: any, customData?: any): void;
   function verbose(message: any, requestId: any, errorCode: any, customData?: any): void;
   function debug(message: any, requestId: any, errorCode: any, customData?: any): void;
+  function wrap(lambdaHandler: LambdaHandler): LambdaHandler;
 }

--- a/libs/logs.d.ts
+++ b/libs/logs.d.ts
@@ -1,7 +1,17 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export default log;
+import {
+  APIGatewayProxyEvent,
+  Context,
+  APIGatewayProxyResult,
+  APIGatewayProxyCallback,
+} from 'aws-lambda';
+
+type LambdaHandler = (
+  event: APIGatewayProxyEvent,
+  context: Context,
+  callback?: APIGatewayProxyCallback
+) => Promise<APIGatewayProxyResult>;
+
 type Primitive = string | number;
-type LambdaHandler = (event: any, context: any, callback?: any) => Promise<unknown>;
 type Level = 'info' | 'error' | 'warn' | 'verbose' | 'debug';
 
 declare namespace log {
@@ -48,5 +58,7 @@ declare namespace log {
     errorCode: Primitive,
     customData?: unknown
   ): void;
-  function wrap(lambdaHandler: LambdaHandler): LambdaHandler;
+  function wrap(lambda: LambdaHandler): LambdaHandler;
 }
+
+export default log;

--- a/libs/logs.d.ts
+++ b/libs/logs.d.ts
@@ -1,15 +1,4 @@
-import {
-  APIGatewayProxyEvent,
-  Context,
-  APIGatewayProxyResult,
-  APIGatewayProxyCallback,
-} from 'aws-lambda';
-
-type LambdaHandler = (
-  event: APIGatewayProxyEvent,
-  context: Context,
-  callback?: APIGatewayProxyCallback
-) => Promise<APIGatewayProxyResult>;
+import { Handler } from 'aws-lambda';
 
 type Primitive = string | number;
 type Level = 'info' | 'error' | 'warn' | 'verbose' | 'debug';
@@ -21,6 +10,9 @@ declare namespace log {
   function writeInfo(message: string, customData?: unknown): void;
   function writeVerbose(message: string, customData?: unknown): void;
   function writeDebug(message: string, customData?: unknown): void;
+  /**
+   * @deprecated
+   */
   function log(
     level: Level,
     message: string,
@@ -28,37 +20,52 @@ declare namespace log {
     errorCode: Primitive,
     customData?: unknown
   ): void;
+  /**
+   * @deprecated
+   */
   function error(
     message: string,
     requestId: string,
     errorCode: Primitive,
     customData?: unknown
   ): void;
+  /**
+   * @deprecated
+   */
   function warn(
     message: string,
     requestId: string,
     errorCode: Primitive,
     customData?: unknown
   ): void;
+  /**
+   * @deprecated
+   */
   function info(
     message: string,
     requestId: string,
     errorCode: Primitive,
     customData?: unknown
   ): void;
+  /**
+   * @deprecated
+   */
   function verbose(
     message: string,
     requestId: string,
     errorCode: Primitive,
     customData?: unknown
   ): void;
+  /**
+   * @deprecated
+   */
   function debug(
     message: string,
     requestId: string,
     errorCode: Primitive,
     customData?: unknown
   ): void;
-  function wrap(lambda: LambdaHandler): LambdaHandler;
+  function wrap(lambda: Handler): Handler;
 }
 
 export default log;

--- a/libs/logs.js
+++ b/libs/logs.js
@@ -7,12 +7,11 @@ const logger = winston.createLogger({
   exitOnError: false,
 });
 
-let requestId = 'N/A';
-
 const log = {
+  requestId: 'N/A',
   writeLog: (level, message, customData = {}) => {
     logger.log(level, message, {
-      requestId,
+      requestId: log.requestId,
       customData,
     });
   },
@@ -20,7 +19,7 @@ const log = {
   log: (level, message, requestId, errorCode, customData = {}) => {
     logger.log(level, message, {
       errorCode,
-      requestId,
+      requestId: log.requestId,
       customData,
     });
   },
@@ -66,7 +65,7 @@ const log = {
   },
 
   initialize: (event, context) => {
-    requestId = context.awsRequestId;
+    log.requestId = context.awsRequestId;
     log.writeInfo('Lambda initialize', {
       source: event.source,
       detailType: event['detail-type'],
@@ -95,7 +94,7 @@ const log = {
       });
 
       if (!(executor instanceof Promise)) {
-        return undefined;
+        return;
       }
 
       const promise = new Promise((resolve, reject) => {

--- a/libs/logs.js
+++ b/libs/logs.js
@@ -74,6 +74,7 @@ const log = {
       method: event.httpMethod,
       pathParameters: event.pathParameters,
       queryStringParameters: event.queryStringParameters,
+      userAgent: event.headers?.['User-Agent'],
     });
   },
 

--- a/libs/logs.js
+++ b/libs/logs.js
@@ -80,7 +80,7 @@ const log = {
   finalize: (response, error) => {
     log.writeInfo('Lambda finalize', {
       statusCode: response?.statusCode ?? 0,
-      error,
+      error: error?.toString(),
     });
   },
 
@@ -97,18 +97,17 @@ const log = {
         return;
       }
 
-      const promise = new Promise((resolve, reject) => {
+      return new Promise((resolve, reject) => {
         executor
           .then(response => {
             log.finalize(response);
             resolve(response);
           })
           .catch(error => {
-            log.finalize(null, error);
             reject(error);
+            log.finalize(null, error);
           });
       });
-      return promise;
     };
   },
 };

--- a/libs/logs.js
+++ b/libs/logs.js
@@ -86,9 +86,8 @@ const log = {
 
   wrap: lambda => {
     return async (event, context) => {
-      log.initialize(event, context);
-
       try {
+        log.initialize(event, context);
         const response = await lambda(event, context);
         log.finalize(response);
         return response;

--- a/libs/logs.js
+++ b/libs/logs.js
@@ -90,7 +90,7 @@ const log = {
 
       const executor = lambda(event, context, (error, response) => {
         log.finalize(response, error);
-        callback(error, response);
+        callback ?? callback(error, response);
       });
 
       if (!(executor instanceof Promise)) {

--- a/libs/logs.js
+++ b/libs/logs.js
@@ -7,9 +7,16 @@ const logger = winston.createLogger({
   exitOnError: false,
 });
 
-let requestId;
+let requestId = 'N/A';
 
 const log = {
+  writeLog: (level, message, customData = {}) => {
+    logger.log(level, message, {
+      requestId,
+      customData,
+    });
+  },
+
   log: (level, message, requestId, errorCode, customData = {}) => {
     logger.log(level, message, {
       errorCode,
@@ -18,20 +25,40 @@ const log = {
     });
   },
 
+  writeError: (message, customData = {}) => {
+    log.writeLog('error', message, customData);
+  },
+
   error: (message, requestId, errorCode, customData = {}) => {
     log.log('error', message, requestId, errorCode, customData);
+  },
+
+  writeWarn: (message, customData = {}) => {
+    log.writeLog('warn', message, customData);
   },
 
   warn: (message, requestId, errorCode, customData = {}) => {
     log.log('warn', message, requestId, errorCode, customData);
   },
 
+  writeInfo: (message, customData = {}) => {
+    log.writeLog('info', message, customData);
+  },
+
   info: (message, requestId, errorCode, customData = {}) => {
     log.log('info', message, requestId, errorCode, customData);
   },
 
+  writeVerbose: (message, customData = {}) => {
+    log.writeLog('verbose', message, customData);
+  },
+
   verbose: (message, requestId, errorCode, customData = {}) => {
     log.log('verbose', message, requestId, errorCode, customData);
+  },
+
+  writeDebug: (message, customData = {}) => {
+    log.writeLog('debug', message, customData);
   },
 
   debug: (message, requestId, errorCode, customData = {}) => {
@@ -40,26 +67,20 @@ const log = {
 
   initialize: (event, context) => {
     requestId = context.awsRequestId;
-    logger.log('info', 'Lambda initialize', {
-      requestId,
-      customData: {
-        source: event.source,
-        detailType: event['detail-type'],
-        path: event.path,
-        method: event.httpMethod,
-        pathParameters: event.pathParameters,
-        queryStringParameters: event.queryStringParameters,
-      },
+    log.writeInfo('Lambda initialize', {
+      source: event.source,
+      detailType: event['detail-type'],
+      path: event.path,
+      method: event.httpMethod,
+      pathParameters: event.pathParameters,
+      queryStringParameters: event.queryStringParameters,
     });
   },
 
   finalize: (response, error) => {
-    logger.log('info', 'Lambda finalize', {
-      requestId,
-      customData: {
-        statusCode: response?.statusCode ?? 0,
-        error,
-      },
+    log.writeInfo('Lambda finalize', {
+      statusCode: response?.statusCode ?? 0,
+      error,
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
+    "@types/aws-lambda": "^8.10.93",
     "@types/jest": "^27.4.0",
     "@types/node": "^14.14.27",
     "@types/uuid": "^8.3.4",


### PR DESCRIPTION
When creating a lambda, wrap the handler with the new log.wrap function to enable start and end logging with extended details automagically.

An example would be
`export const main = log.wrap(async (event, context) => {...`

instead of:
`export const main = async (event, context) => {...`

That is ALL that needs to be done.
The measure will add the following info message types to each request:
"message": "Lambda initialize"
"message": "Lambda finalize"

Each with their own set of metrics.
The initialiser will automatically log the source and detail type of any EventBridge event triggering the lambda.

A complete log-event for a lambda function triggered by EventBridge:
```
{
    "customData": {
        "detailType": "applicationReceivedSuccess",
        "source": "vivaMs.submitApplication"
    },
    "level": "info",
    "message": "Lambda initialize",
    "requestId": "56345ca8-da7c-479f-8e41-1ea8c1bdeaae"
}
```
A complete log-event for a lambda function triggered by API-gateway:
```
{
    "customData": {
        "method": "POST",
        "path": "/auth/bankid/auth",
        "pathParameters": null,
        "queryStringParameters": null,
        "userAgent": "MittHelsingborg/1.1.4/ios/15.2"
    },
    "level": "info",
    "message": "Lambda initialize",
    "requestId": "19303d83-3793-48a6-a6d2-ab71cba56345"
}
```

### How to test
1. Wrap a function with the log.wrap statement as described above
2. Deploy with SLS
3. Invoke the function
4. Verify the CloudWatch log of the lambda to see that the two log entries "Lambda initialise" and "Lambda finalise" is printed