### PR TITLE
fix: add decrypt privilege to bank id api

### DIFF
--- a/services/bankid-api/serverless.yml
+++ b/services/bankid-api/serverless.yml
@@ -61,6 +61,10 @@ provider:
             - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${file(../../config.json):${self:custom.stage}.auth.secrets.refreshToken.name}-??????'
             - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${file(../../config.json):${self:custom.stage}.auth.secrets.authorizationCode.name}-??????'
 
+        - Effect: Allow
+          Action:
+            - kms:Decrypt
+          Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
 functions:
   auth:
     handler: src/lambdas/auth.main


### PR DESCRIPTION
To be able to decrypt the certificate storage S3 bucket, bankid needs to
have privileges defined in the serverless.yml

