### PR TITLE
feat(synccasecompletions): stop execution when new application

### DIFF
--- a/services/viva-ms/src/lambdas/syncCaseCompletions.ts
+++ b/services/viva-ms/src/lambdas/syncCaseCompletions.ts
@@ -40,7 +40,7 @@ export async function main(event: LambdaEvent, context: LambdaContext) {
       'service-viva-ms-syncCaseCompletions-005',
       undefined
     );
-    return false;
+    return true;
   }
 
   const [getLatestWorkflowIdError, latestWorkflowId] = await to(


### PR DESCRIPTION
## Explain the changes you’ve made
Stop execution of lambda when status list only contains status code for new application

## Explain why these changes are made
Since a new application doesn't have any completions to sync, the execution of the lambda function is unnecessary.

## Explain your solution
check the incoming status list and check if it only contains the id for new application. If it does, stop the execution.

## How to test

Concrete example:

1. Checkout this branch
2. run `sls deploy` within service folder for `service x`
3. ...etc.

## Tested environments

- [x] Your personal AWS environment.
- [] Your local Serverless environment.
