### PR TITLE
feat: add lib to jest coverage ignore 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
       babelConfig: 'babel.config.js',
     },
   },
+  coveragePathIgnorePatterns: ['/libs/'],
   coverageThreshold: {
     global: {
       branches: 80,


### PR DESCRIPTION
Coverage is now ignoring the /libs/ directory making lambda testing easier

coveragePathIgnorePatterns: ['/libs/'],

