### PR TITLE
Feat/use correct form after submit

### DIFF
--- a/libs/query/cases/caseQueries.ts
+++ b/libs/query/cases/caseQueries.ts
@@ -1,0 +1,12 @@
+import { caseQuaryHandler } from '../handlers/dynamoDb/caseQueryHandler';
+
+import { CaseQueryHandler } from './types';
+
+export const caseQueries: CaseQueryHandler = {
+  async get(keys: { PK: string; SK?: string }) {
+    return caseQuaryHandler.get({
+      PK: keys.PK,
+      SK: keys.SK,
+    });
+  },
+};

--- a/libs/query/cases/types.ts
+++ b/libs/query/cases/types.ts
@@ -1,0 +1,5 @@
+import { CaseItem } from '../../../types/caseItem';
+
+export interface CaseQueryHandler {
+  get(keys: { PK: string; SK?: string }): Promise<CaseItem>;
+}

--- a/libs/query/handlers/dynamoDb/caseQueryHandler.ts
+++ b/libs/query/handlers/dynamoDb/caseQueryHandler.ts
@@ -6,6 +6,7 @@ import type { CaseQueryHandler } from '../../cases/types';
 
 export const caseQuaryHandler: CaseQueryHandler = {
   async get(keys: { PK: string; SK: string }) {
-    return dynamoQueryHandler.get(config.cases.tableName, keys);
+    const casesTableName = `${config.resourceStage}-${config.cases.tableName}`;
+    return dynamoQueryHandler.get(casesTableName, keys);
   },
 };

--- a/libs/query/handlers/dynamoDb/caseQueryHandler.ts
+++ b/libs/query/handlers/dynamoDb/caseQueryHandler.ts
@@ -1,0 +1,11 @@
+import { dynamoQueryHandler } from './queryHandler';
+
+import config from '../../../config';
+
+import type { CaseQueryHandler } from '../../cases/types';
+
+export const caseQuaryHandler: CaseQueryHandler = {
+  async get(keys: { PK: string; SK: string }) {
+    return dynamoQueryHandler.get(config.cases.tableName, keys);
+  },
+};

--- a/libs/query/handlers/dynamoDb/queryHandler.ts
+++ b/libs/query/handlers/dynamoDb/queryHandler.ts
@@ -1,0 +1,20 @@
+import DynamoDb from 'aws-sdk/clients/dynamodb';
+
+const dynamoDbClient = new DynamoDb.DocumentClient({ apiVersion: '2012-08-10' });
+
+import { DynamoQueryHandler } from './types';
+
+export const dynamoQueryHandler: DynamoQueryHandler = {
+  async get<T>(tableName: string, keys: { PK: string; SK?: string }) {
+    const parameters = {
+      TableName: tableName,
+      Key: {
+        PK: keys.PK,
+        SK: keys.SK,
+      },
+    };
+
+    const result = await dynamoDbClient.get(parameters).promise();
+    return result.Item as T;
+  },
+};

--- a/libs/query/handlers/dynamoDb/types.ts
+++ b/libs/query/handlers/dynamoDb/types.ts
@@ -1,0 +1,3 @@
+export interface DynamoQueryHandler {
+  get<T>(tableName: string, keys: { PK: string; SK?: string }): Promise<T>;
+}

--- a/libs/query/index.ts
+++ b/libs/query/index.ts
@@ -1,0 +1,3 @@
+import { caseQueries as cases } from './cases/caseQueries';
+
+export { cases };

--- a/services/viva-ms/src/helpers/dynamoDb.js
+++ b/services/viva-ms/src/helpers/dynamoDb.js
@@ -157,3 +157,33 @@ export function destructRecord(record) {
   const body = JSON.parse(record.body);
   return dynamoDb.unmarshall(body.detail.dynamodb.NewImage);
 }
+
+export function updateCaseCompletionStatus(keys, caseUpdateAttributes) {
+  const { newStatus, newState, newCurrentFormId, newPersons } = caseUpdateAttributes;
+
+  const updateParams = {
+    TableName: config.cases.tableName,
+    Key: {
+      PK: keys.PK,
+      SK: keys.SK,
+    },
+    UpdateExpression:
+      'SET #currentFormId = :newCurrentFormId, #status = :newStatus, #persons = :newPersons, #state = :newState',
+    ExpressionAttributeNames: {
+      '#currentFormId': 'currentFormId',
+      '#status': 'status',
+      '#persons': 'persons',
+      '#state': 'state',
+    },
+    ExpressionAttributeValues: {
+      ':newCurrentFormId': newCurrentFormId,
+      ':newPersons': newPersons,
+      ':newStatus': newStatus,
+      ':newState': newState,
+    },
+    ProjectionExpression: 'id',
+    ReturnValues: 'ALL_NEW',
+  };
+
+  return dynamoDb.call('update', updateParams);
+}

--- a/services/viva-ms/src/helpers/resetPersonSignature.ts
+++ b/services/viva-ms/src/helpers/resetPersonSignature.ts
@@ -1,9 +1,9 @@
-import { CasePerson } from '../types/caseItem';
+import { CasePerson, CasePersonRole } from '../types/caseItem';
 
 export default function resetPersonSignature(person: CasePerson) {
   const personCopy = { ...person };
 
-  if (personCopy.role === 'applicant' && personCopy.hasSigned) {
+  if (personCopy.role === CasePersonRole.Applicant && personCopy.hasSigned) {
     personCopy.hasSigned = false;
   }
 

--- a/services/viva-ms/src/helpers/resetPersonSignature.ts
+++ b/services/viva-ms/src/helpers/resetPersonSignature.ts
@@ -1,0 +1,11 @@
+import { CasePerson } from '../types/caseItem';
+
+export default function resetPersonSignature(person: CasePerson) {
+  const personCopy = { ...person };
+
+  if (personCopy.role === 'applicant' && personCopy.hasSigned) {
+    personCopy.hasSigned = false;
+  }
+
+  return personCopy;
+}

--- a/services/viva-ms/src/lambdas/setCaseCompletions.ts
+++ b/services/viva-ms/src/lambdas/setCaseCompletions.ts
@@ -30,8 +30,8 @@ export interface Dependencies {
   updateCase: (keys: CaseKeys, caseUpdateAttributes: unknown) => Promise<void>;
 }
 
-export async function setCaseCompletions(event: LambdaRequest, dependencies: Dependencies) {
-  const { caseKeys } = event.detail;
+export async function setCaseCompletions(input: LambdaRequest, dependencies: Dependencies) {
+  const { caseKeys } = input.detail;
   const { getCase, readParams, putSuccessEvent, updateCase } = dependencies;
 
   const caseItem = await getCase(caseKeys);
@@ -62,7 +62,7 @@ export async function setCaseCompletions(event: LambdaRequest, dependencies: Dep
   };
 
   await updateCase(caseKeys, caseUpdateAttributes);
-  await putSuccessEvent(event.detail);
+  await putSuccessEvent(input.detail);
 
   return true;
 }

--- a/services/viva-ms/src/lambdas/setCaseCompletions.ts
+++ b/services/viva-ms/src/lambdas/setCaseCompletions.ts
@@ -13,7 +13,7 @@ import { CaseItem } from '../types/caseItem';
 import { SSMParameters } from '../types/ssmParameters';
 
 type CaseKeys = Pick<CaseItem, 'PK' | 'SK'>;
-type Case = Pick<CaseItem, 'details' | 'persons' | 'currentFormId' | 'id'>;
+type UserCase = Pick<CaseItem, 'details' | 'persons' | 'currentFormId' | 'id'>;
 
 interface LambdaDetails {
   caseKeys: CaseKeys;
@@ -25,7 +25,7 @@ export interface LambdaRequest {
 
 export interface Dependencies {
   writeInfo: typeof log.writeInfo;
-  getCase: (keys: CaseKeys) => Promise<Case>;
+  getCase: (keys: CaseKeys) => Promise<UserCase>;
   readParams: (envsKeyName: string) => Promise<SSMParameters>;
   putSuccessEvent: (params: LambdaDetails) => Promise<null>;
   updateCase: (keys: CaseKeys, caseUpdateAttributes: unknown) => Promise<void>;

--- a/services/viva-ms/src/lambdas/setCaseCompletions.ts
+++ b/services/viva-ms/src/lambdas/setCaseCompletions.ts
@@ -30,15 +30,6 @@ export interface Dependencies {
   updateCase: (keys: CaseKeys, caseUpdateAttributes: unknown) => Promise<void>;
 }
 
-export const main = log.wrap(async event => {
-  return setCaseCompletions(event, {
-    getCase: cases.get,
-    readParams: params.read,
-    putSuccessEvent: putVivaMsEvent.setCaseCompletionsSuccess,
-    updateCase: updateCaseCompletionStatus,
-  });
-});
-
 export async function setCaseCompletions(event: LambdaRequest, dependencies: Dependencies) {
   const { caseKeys } = event.detail;
   const { getCase, readParams, putSuccessEvent, updateCase } = dependencies;
@@ -75,3 +66,12 @@ export async function setCaseCompletions(event: LambdaRequest, dependencies: Dep
 
   return true;
 }
+
+export const main = log.wrap(async event => {
+  return setCaseCompletions(event, {
+    getCase: cases.get,
+    readParams: params.read,
+    putSuccessEvent: putVivaMsEvent.setCaseCompletionsSuccess,
+    updateCase: updateCaseCompletionStatus,
+  });
+});

--- a/services/viva-ms/src/lambdas/setCaseCompletions.ts
+++ b/services/viva-ms/src/lambdas/setCaseCompletions.ts
@@ -25,7 +25,7 @@ export interface LambdaRequest {
 
 export interface Dependencies {
   writeInfo: typeof log.writeInfo;
-  getCase: (keys: { PK: string; SK?: string }) => Promise<Case>;
+  getCase: (keys: CaseKeys) => Promise<Case>;
   readParams: (envsKeyName: string) => Promise<SSMParameters>;
   putSuccessEvent: (params: LambdaDetails) => Promise<null>;
   updateCase: (keys: CaseKeys, caseUpdateAttributes: unknown) => Promise<void>;

--- a/services/viva-ms/src/lambdas/setCaseCompletions.ts
+++ b/services/viva-ms/src/lambdas/setCaseCompletions.ts
@@ -10,7 +10,7 @@ import resetPersonSignature from '../helpers/resetPersonSignature';
 import { updateCaseCompletionStatus } from '../helpers/dynamoDb';
 
 import { CaseItem } from '../types/caseItem';
-import { SSMParameters } from '../types/ssmParameters';
+import { VivaParametersResponse } from '../types/ssmParameters';
 
 type CaseKeys = Pick<CaseItem, 'PK' | 'SK'>;
 type UserCase = Pick<CaseItem, 'details' | 'persons' | 'currentFormId' | 'id'>;
@@ -25,7 +25,7 @@ export interface LambdaRequest {
 
 export interface Dependencies {
   getCase: (keys: CaseKeys) => Promise<UserCase>;
-  readParams: (envsKeyName: string) => Promise<SSMParameters>;
+  readParams: (envsKeyName: string) => Promise<VivaParametersResponse>;
   putSuccessEvent: (params: LambdaDetails) => Promise<null>;
   updateCase: (keys: CaseKeys, caseUpdateAttributes: unknown) => Promise<void>;
 }

--- a/services/viva-ms/src/lambdas/setCaseCompletions.ts
+++ b/services/viva-ms/src/lambdas/setCaseCompletions.ts
@@ -24,7 +24,6 @@ export interface LambdaRequest {
 }
 
 export interface Dependencies {
-  writeInfo: typeof log.writeInfo;
   getCase: (keys: CaseKeys) => Promise<UserCase>;
   readParams: (envsKeyName: string) => Promise<SSMParameters>;
   putSuccessEvent: (params: LambdaDetails) => Promise<null>;
@@ -33,7 +32,6 @@ export interface Dependencies {
 
 export const main = log.wrap(async event => {
   return setCaseCompletions(event, {
-    writeInfo: log.writeInfo,
     getCase: cases.get,
     readParams: params.read,
     putSuccessEvent: putVivaMsEvent.setCaseCompletionsSuccess,
@@ -43,7 +41,7 @@ export const main = log.wrap(async event => {
 
 export async function setCaseCompletions(event: LambdaRequest, dependencies: Dependencies) {
   const { caseKeys } = event.detail;
-  const { writeInfo, getCase, readParams, putSuccessEvent, updateCase } = dependencies;
+  const { getCase, readParams, putSuccessEvent, updateCase } = dependencies;
 
   const caseItem = await getCase(caseKeys);
 
@@ -74,8 +72,6 @@ export async function setCaseCompletions(event: LambdaRequest, dependencies: Dep
 
   await updateCase(caseKeys, caseUpdateAttributes);
   await putSuccessEvent(event.detail);
-
-  writeInfo('Successfully updated case', caseItem.id);
 
   return true;
 }

--- a/services/viva-ms/src/types/caseItem.ts
+++ b/services/viva-ms/src/types/caseItem.ts
@@ -22,11 +22,13 @@ interface RequestedCaseCompletions {
 }
 
 export interface CaseCompletions {
-  requested: RequestedCaseCompletions[];
-  attachmentUploaded: string[];
-  randomCheck: boolean;
-  completed: boolean;
-  dueDate: number;
+  requested?: RequestedCaseCompletions[];
+  attachmentUploaded?: string[];
+  completed?: boolean;
+  dueDate?: number;
+  isCompleted?: boolean;
+  isAttachmentPending?: boolean;
+  isRandomCheck?: boolean;
 }
 
 export interface CaseItem {
@@ -51,7 +53,7 @@ export interface CaseDetails {
   workflowId: string | null;
   period: CasePeriod;
   readonly workflow?: unknown;
-  completions: CaseCompletions;
+  completions?: CaseCompletions;
 }
 
 export interface CaseStatus {

--- a/services/viva-ms/src/types/caseItem.ts
+++ b/services/viva-ms/src/types/caseItem.ts
@@ -16,6 +16,19 @@ export interface CaseUserAddress {
   readonly postalCode?: string;
 }
 
+interface RequestedCaseCompletions {
+  description: string;
+  received: boolean;
+}
+
+export interface CaseCompletions {
+  requested: RequestedCaseCompletions[];
+  attachmentUploaded: string[];
+  randomCheck: boolean;
+  completed: boolean;
+  dueDate: number;
+}
+
 export interface CaseItem {
   id: string;
   PK: string;
@@ -38,6 +51,7 @@ export interface CaseDetails {
   workflowId: string | null;
   period: CasePeriod;
   readonly workflow?: unknown;
+  completions: CaseCompletions;
 }
 
 export interface CaseStatus {

--- a/services/viva-ms/src/types/caseItem.ts
+++ b/services/viva-ms/src/types/caseItem.ts
@@ -22,13 +22,13 @@ interface RequestedCaseCompletions {
 }
 
 export interface CaseCompletions {
-  requested?: RequestedCaseCompletions[];
-  attachmentUploaded?: string[];
-  completed?: boolean;
-  dueDate?: number;
-  isCompleted?: boolean;
-  isAttachmentPending?: boolean;
-  isRandomCheck?: boolean;
+  readonly requested: RequestedCaseCompletions[];
+  readonly attachmentUploaded: string[];
+  readonly completed: boolean;
+  readonly dueDate: number | null;
+  readonly isCompleted: boolean;
+  readonly isAttachmentPending: boolean;
+  readonly isRandomCheck: boolean;
 }
 
 export interface CaseItem {

--- a/services/viva-ms/src/types/ssmParameters.ts
+++ b/services/viva-ms/src/types/ssmParameters.ts
@@ -1,0 +1,7 @@
+export interface SSMParameters {
+  randomCheckFormId: string;
+  completionFormId: string;
+  newApplicationFormId: string;
+  newApplicationRandomCheckFormId: string;
+  newApplicationCompletionFormId: string;
+}

--- a/services/viva-ms/src/types/ssmParameters.ts
+++ b/services/viva-ms/src/types/ssmParameters.ts
@@ -1,4 +1,5 @@
 export interface SSMParameters {
+  recurringFormId: string;
   randomCheckFormId: string;
   completionFormId: string;
   newApplicationFormId: string;

--- a/services/viva-ms/src/types/ssmParameters.ts
+++ b/services/viva-ms/src/types/ssmParameters.ts
@@ -1,4 +1,4 @@
-export interface SSMParameters {
+export interface VivaParametersResponse {
   recurringFormId: string;
   randomCheckFormId: string;
   completionFormId: string;

--- a/services/viva-ms/test/helpers/resetPersonSignature.test.ts
+++ b/services/viva-ms/test/helpers/resetPersonSignature.test.ts
@@ -1,0 +1,58 @@
+import resetPersonSignature from '../../src/helpers/resetPersonSignature';
+
+import { CasePersonRole } from '../../src/types/caseItem';
+
+test.each([
+  {
+    role: CasePersonRole.Applicant,
+    hasSigned: false,
+    expected: false,
+  },
+  {
+    role: CasePersonRole.Children,
+    hasSigned: false,
+    expected: false,
+  },
+  {
+    role: CasePersonRole.CoApplicant,
+    hasSigned: false,
+    expected: false,
+  },
+  {
+    role: CasePersonRole.Unknown,
+    hasSigned: false,
+    expected: false,
+  },
+  {
+    role: CasePersonRole.Applicant,
+    hasSigned: true,
+    expected: false,
+  },
+  {
+    role: CasePersonRole.Children,
+    hasSigned: true,
+    expected: true,
+  },
+  {
+    role: CasePersonRole.CoApplicant,
+    hasSigned: true,
+    expected: true,
+  },
+  {
+    role: CasePersonRole.Unknown,
+    hasSigned: true,
+    expected: true,
+  },
+])('role: $role, hasSigned: $hasSigned, expected: $expected', ({ role, hasSigned, expected }) => {
+  const person = {
+    personalNumber: '19900102-1234',
+    firstName: 'firstName',
+    lastName: 'lastName',
+    role,
+    hasSigned,
+  };
+
+  const result = resetPersonSignature(person);
+
+  expect(result.hasSigned).toBe(expected);
+});

--- a/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
+++ b/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
@@ -105,7 +105,6 @@ test.each([
 
     const updateCaseMock = jest.fn();
     const dependencies: Dependencies = {
-      writeInfo: jest.fn(),
       getCase: () => Promise.resolve(caseItem),
       putSuccessEvent: () => Promise.resolve(null),
       readParams: () => Promise.resolve(ssmParameters),

--- a/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
+++ b/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
@@ -1,0 +1,126 @@
+import {
+  setCaseCompletions,
+  Dependencies,
+  LambdaRequest,
+} from '../../src/lambdas/setCaseCompletions';
+
+import { VIVA_COMPLETION_REQUIRED, VIVA_RANDOM_CHECK_REQUIRED } from '../../src/libs/constants';
+
+const ssmParameters = {
+  recurringFormId: 'recurring',
+  randomCheckFormId: 'randomCheck',
+  completionFormId: 'completionForm',
+  newApplicationFormId: 'newApplication',
+  newApplicationRandomCheckFormId: 'newApplicationRandomCheck',
+  newApplicationCompletionFormId: 'newApplicationCompletion',
+};
+
+const caseKeys = {
+  PK: 'PK',
+  SK: 'SK',
+};
+
+const event: LambdaRequest = {
+  detail: {
+    caseKeys,
+  },
+};
+
+const getCaseItem = (
+  currentFormId: string,
+  isRandomCheck: boolean,
+  requested: { received: boolean; description: string }[]
+) => ({
+  currentFormId,
+  id: 'caseId',
+  persons: [],
+  details: {
+    workflowId: 'flowId',
+    period: {
+      startDate: 1,
+      endDate: 2,
+    },
+    completions: {
+      isRandomCheck,
+      requested,
+    },
+  },
+});
+
+test.each([
+  {
+    description: 'it updates a recurring case for randomCheck with correct parameters',
+    currentFormId: ssmParameters.recurringFormId,
+    isRandomCheck: true,
+    newCurrentFormId: ssmParameters.randomCheckFormId,
+    requestedCompletions: [{ received: false, description: '' }],
+    newState: VIVA_RANDOM_CHECK_REQUIRED,
+  },
+  {
+    description: 'it updates a recurring case for completions with correct parameters',
+    currentFormId: ssmParameters.recurringFormId,
+    isRandomCheck: true,
+    newCurrentFormId: ssmParameters.completionFormId,
+    requestedCompletions: [{ received: true, description: '' }],
+    newState: VIVA_COMPLETION_REQUIRED,
+  },
+  {
+    description:
+      'it updates a recurring case for completions with correct parameters, no completions received before',
+    currentFormId: ssmParameters.recurringFormId,
+    isRandomCheck: false,
+    requestedCompletions: [{ received: false, description: '' }],
+    newCurrentFormId: ssmParameters.completionFormId,
+    newState: VIVA_COMPLETION_REQUIRED,
+  },
+  {
+    description: 'it updates a new application case for randomCheck with correct parameters',
+    currentFormId: ssmParameters.newApplicationFormId,
+    isRandomCheck: true,
+    requestedCompletions: [{ received: false, description: '' }],
+    newCurrentFormId: ssmParameters.newApplicationRandomCheckFormId,
+    newState: VIVA_RANDOM_CHECK_REQUIRED,
+  },
+  {
+    description: 'it updates a new application case for completions with correct parameters',
+    currentFormId: ssmParameters.newApplicationFormId,
+    isRandomCheck: true,
+    requestedCompletions: [{ received: true, description: '' }],
+    newCurrentFormId: ssmParameters.newApplicationCompletionFormId,
+    newState: VIVA_COMPLETION_REQUIRED,
+  },
+  {
+    description:
+      'it updates a new application case for completions with correct parameters, no completions received before',
+    currentFormId: ssmParameters.newApplicationFormId,
+    isRandomCheck: false,
+    requestedCompletions: [{ received: false, description: '' }],
+    newCurrentFormId: ssmParameters.newApplicationCompletionFormId,
+    newState: VIVA_COMPLETION_REQUIRED,
+  },
+])(
+  '$description',
+  async ({ currentFormId, isRandomCheck, requestedCompletions, newCurrentFormId, newState }) => {
+    const caseItem = getCaseItem(currentFormId, isRandomCheck, requestedCompletions);
+
+    const updateCaseMock = jest.fn();
+    const dependencies: Dependencies = {
+      writeInfo: jest.fn(),
+      getCase: () => Promise.resolve(caseItem),
+      putSuccessEvent: () => Promise.resolve(null),
+      readParams: () => Promise.resolve(ssmParameters),
+      updateCase: updateCaseMock,
+    };
+
+    const result = await setCaseCompletions(event, dependencies);
+
+    expect(result).toBe(true);
+    expect(updateCaseMock).toHaveBeenCalledWith(
+      caseKeys,
+      expect.objectContaining({
+        newCurrentFormId,
+        newState,
+      })
+    );
+  }
+);

--- a/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
+++ b/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
@@ -20,7 +20,7 @@ const caseKeys = {
   SK: 'SK',
 };
 
-const event: LambdaRequest = {
+const input: LambdaRequest = {
   detail: {
     caseKeys,
   },
@@ -116,7 +116,7 @@ test.each([
       updateCase: updateCaseMock,
     };
 
-    const result = await setCaseCompletions(event, dependencies);
+    const result = await setCaseCompletions(input, dependencies);
 
     expect(result).toBe(true);
     expect(updateCaseMock).toHaveBeenCalledWith(

--- a/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
+++ b/services/viva-ms/test/lambdas/setCaseCompletions.test.ts
@@ -43,6 +43,11 @@ const getCaseItem = (
     completions: {
       isRandomCheck,
       requested,
+      attachmentUploaded: [],
+      completed: false,
+      dueDate: null,
+      isCompleted: false,
+      isAttachmentPending: false,
     },
   },
 });


### PR DESCRIPTION
## Explain the changes you’ve made
Set the correct `currentFormId` depending on previous form id.

## Explain why these changes are made
Since the forms for random check and completions are different for new application case, the `currentFormId` needs to be changed accordingly.

## Explain your solution
Check the current form id in a case, if it belongs to a new application, then change form ids sent to the completions helper function. By doing this check in the `setCaseCompletions` lambda we don't need to do any other changes in other parts of the code base.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service x`

## Tested environments

- [x] Your personal AWS environment.
- [] Your local Serverless environment.
