### PR TITLE
feat: add form ids for new application

### DIFF
--- a/services/viva-ms/src/lambdas/createNewVivaCase.ts
+++ b/services/viva-ms/src/lambdas/createNewVivaCase.ts
@@ -60,14 +60,19 @@ export async function lambda(
   lambdaContext: LambdaContext
 ): Promise<boolean> {
   const { user } = event.detail;
-  const { newApplicationFormId } = await params.read(config.cases.providers.viva.envsKeyName);
+  const { newApplicationFormId, newApplicationCompletionFormId, newApplicationRandomCheckFormId } =
+    await params.read(config.cases.providers.viva.envsKeyName);
 
   const [, queryResponse] = await to(getUserCaseList(user.personalNumber));
   if (queryResponse?.Count) {
     return true;
   }
 
-  const formIdList = [newApplicationFormId];
+  const formIdList = [
+    newApplicationFormId,
+    newApplicationCompletionFormId,
+    newApplicationRandomCheckFormId,
+  ];
   const isCoApplicant = false;
   const initialFormEncryption = createCaseHelper.getFormEncryptionAttributes(isCoApplicant);
   const initialFormList = createCaseHelper.getInitialFormAttributes(


### PR DESCRIPTION
## Explain the changes you’ve made
CreateNewVivaCase lambda were missing form ids for random check and completions for new application, hence adding those.

## Explain why these changes are made
When a new case for new application is created, the default value for answers, encryption and position is missing for random check and completions. Therefore they needed to be added.

## Explain your solution
Added the missing `newApplicationRandomCheckFormId` and `newApplicationCompletionFormId` in the formIdList which creates the default values in DynamoDb.

## How to test

Example when running the lambda locally:
1. Make sure that your test person does not have any cases in the cases table
2. Make sure that you have the `newApplicationCompletionFormId` and `newApplicationRandomCheckFormId` ssm parameters in vivaEnvs in AWS SSM
3. Run the lambda function
4. Check the created case in dynamoDb table and make sure you have 3 forms with default values in it

- [x] Your personal AWS environment.
- [] Your local Serverless environment.
