### PR TITLE
feat: add typescript build as build task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
       "skipFiles": ["<node_internals>/**"],
       "program": "${file}",
       "envFile": "${workspaceFolder}/.env",
-      "outputCapture": "std"
+      "outputCapture": "std",
+      "preLaunchTask": "ts-build"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "ts-build",
+      "type": "shell",
+      "command": "npx tsc",
+      "options": {
+        "cwd": "${fileDirname}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "showReuseMessage": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When starting debugger or executing default build task
tsc will be run automatically.
