### PR TITLE
fix(viva-ms): handle undefined/invalid form ids

### DIFF
--- a/services/viva-ms/src/helpers/dynamoDb.js
+++ b/services/viva-ms/src/helpers/dynamoDb.js
@@ -103,6 +103,14 @@ export async function getLastUpdatedCase(PK) {
   return sortedCases?.[0] || {};
 }
 
+async function getAlways(params) {
+  const res = await dynamoDb.call('get', params);
+  if (!res.Item) {
+    throw new Error(`unable to get item ${params.TableName} ${JSON.stringify(params.Key)}`);
+  }
+  return res;
+}
+
 export async function getFormTemplates(formIdList) {
   const [getError, formTemplateList] = await to(
     Promise.all(
@@ -111,7 +119,7 @@ export async function getFormTemplates(formIdList) {
           TableName: config.forms.tableName,
           Key: { PK: `FORM#${formId}` },
         };
-        return dynamoDb.call('get', getFormParams);
+        return getAlways(getFormParams);
       })
     )
   );

--- a/services/viva-ms/src/helpers/dynamoDb.js
+++ b/services/viva-ms/src/helpers/dynamoDb.js
@@ -104,28 +104,24 @@ export async function getLastUpdatedCase(PK) {
 }
 
 async function getAlways(params) {
-  const res = await dynamoDb.call('get', params);
-  if (!res.Item) {
+  const result = await dynamoDb.call('get', params);
+
+  if (!result.Item) {
     throw new Error(`unable to get item ${params.TableName} ${JSON.stringify(params.Key)}`);
   }
-  return res;
+  return result;
 }
 
 export async function getFormTemplates(formIdList) {
-  const [getError, formTemplateList] = await to(
-    Promise.all(
-      formIdList.map(formId => {
-        const getFormParams = {
-          TableName: config.forms.tableName,
-          Key: { PK: `FORM#${formId}` },
-        };
-        return getAlways(getFormParams);
-      })
-    )
+  const formTemplateList = await Promise.all(
+    formIdList.map(formId => {
+      const getFormParams = {
+        TableName: config.forms.tableName,
+        Key: { PK: `FORM#${formId}` },
+      };
+      return getAlways(getFormParams);
+    })
   );
-  if (getError) {
-    throw getError;
-  }
 
   return formTemplateList.reduce(
     (accumulatedFormList, currentForm) => ({

--- a/services/viva-ms/src/lambdas/createNewVivaCase.ts
+++ b/services/viva-ms/src/lambdas/createNewVivaCase.ts
@@ -134,12 +134,12 @@ export async function createNewVivaCase(
     currentFormId: newApplicationFormId,
   };
 
-  const createdCaseItem = (await createCase({
+  await createCase({
     TableName: config.cases.tableName,
     Item: newVivaCaseItem,
-  })) as CaseItem;
+  });
 
-  log.writeInfo(`New case with id: ${createdCaseItem.id} successfully created`);
+  log.writeInfo(`New case with id: ${newVivaCaseItem.id} successfully created`);
 
   return true;
 }


### PR DESCRIPTION
## Explain the changes you’ve made
Handle undefined form ids

## Explain why these changes are made
When trying to fetch from dynamoDb with a `PK` that doesn't exist, the dynamodb.call function does not throw if the item could not be found. This resulted in that the reduce function tried to access an id which were undefined, causing the application to crash.

## Explain your solution
Changed the function call when fetching template forms so we throw when the `Item` property doesn't exist and throw a more explained error message.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `viva-ms`
3. ... or run lambda locally

## Tested environments

- [x] Your personal AWS environment.
- [] Your local Serverless environment.
