### PR TITLE
fix: add total number of steps

### DIFF
--- a/services/cases-api/src/helpers/schema.js
+++ b/services/cases-api/src/helpers/schema.js
@@ -36,6 +36,7 @@ const formCurrentPosition = Joi.object({
   level: Joi.number().required(),
   currentMainStep: Joi.number().required(),
   currentMainStepIndex: Joi.number().required(),
+  numberOfMainSteps: Joi.number().default(0),
 });
 
 const signature = Joi.object({

--- a/services/viva-ms/src/helpers/constants.js
+++ b/services/viva-ms/src/helpers/constants.js
@@ -72,3 +72,11 @@ export const VIVA_STATUS_COMPLETION = 64;
 export const VIVA_STATUS_CASE_EXISTS = 128;
 export const VIVA_STATUS_WEB_APPLICATION_ACTIVE = 256;
 export const VIVA_STATUS_WEB_APPLICATION_ALLOWED = 512;
+
+export const DEFAULT_CURRENT_POSITION = {
+  currentMainStep: 1,
+  currentMainStepIndex: 0,
+  index: 0,
+  level: 0,
+  numberOfMainSteps: 0,
+};

--- a/services/viva-ms/src/helpers/createCase.ts
+++ b/services/viva-ms/src/helpers/createCase.ts
@@ -16,6 +16,8 @@ import {
   EncryptionType,
 } from '../types/caseItem';
 
+import { DEFAULT_CURRENT_POSITION } from './constants';
+
 export interface CasePersonRoleType {
   readonly client: CasePersonRole.Applicant;
   readonly partner: CasePersonRole.CoApplicant;
@@ -99,15 +101,9 @@ function getInitialFormAttributes(
   encryption: CaseFormEncryption
 ): Record<string, CaseForm> {
   const initialFormAttributes: CaseForm = {
-    answers: [],
     encryption,
-    currentPosition: {
-      currentMainStep: 1,
-      currentMainStepIndex: 0,
-      index: 0,
-      level: 0,
-      numberOfMainSteps: 0,
-    },
+    answers: [],
+    currentPosition: DEFAULT_CURRENT_POSITION,
   };
 
   return formIdList.reduce(

--- a/services/viva-ms/src/helpers/createCase.ts
+++ b/services/viva-ms/src/helpers/createCase.ts
@@ -106,6 +106,7 @@ function getInitialFormAttributes(
       currentMainStepIndex: 0,
       index: 0,
       level: 0,
+      numberOfMainSteps: 0,
     },
   };
 

--- a/services/viva-ms/src/types/caseItem.ts
+++ b/services/viva-ms/src/types/caseItem.ts
@@ -104,6 +104,7 @@ export interface CaseFormCurrentPosition {
   currentMainStepIndex: number;
   index: number;
   level: number;
+  numberOfMainSteps: number;
 }
 
 export interface CaseFormAnswer {

--- a/services/viva-ms/test/helpers/createCase.test.ts
+++ b/services/viva-ms/test/helpers/createCase.test.ts
@@ -9,7 +9,14 @@ import {
   VivaPersonsPerson,
   VivaPersonType,
 } from '../../src/types/vivaMyPages';
-import { CasePerson, CasePeriod } from '../../src/types/caseItem';
+import {
+  CasePerson,
+  CasePeriod,
+  CaseFormEncryption,
+  EncryptionType,
+} from '../../src/types/caseItem';
+
+import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
 
 const vivaApplication: VivaMyPagesPersonApplication = {
   workflowid: '123',
@@ -124,5 +131,29 @@ describe('getCasePersonList', () => {
         hasSigned: false,
       },
     ]);
+  });
+});
+
+describe('getInitialFormAttributes', () => {
+  it('returns initial form attributes', () => {
+    const formIds = ['1', '2'];
+
+    const caseEncryption: CaseFormEncryption = {
+      type: EncryptionType.Decrypted,
+      symmetricKeyName: 'symmetricKeyName',
+    };
+
+    const expectedDefaultValue = {
+      encryption: caseEncryption,
+      answers: [],
+      currentPosition: DEFAULT_CURRENT_POSITION,
+    };
+
+    const result = caseHelper.getInitialFormAttributes(formIds, caseEncryption);
+
+    expect(result).toEqual({
+      [formIds[0]]: expectedDefaultValue,
+      [formIds[1]]: expectedDefaultValue,
+    });
   });
 });

--- a/services/viva-ms/test/helpers/createCase.test.ts
+++ b/services/viva-ms/test/helpers/createCase.test.ts
@@ -68,55 +68,61 @@ const vivaCaseWithPersonList: VivaMyPagesPersonCase = {
   persons: vivaPersonList,
 };
 
-it('Results in a string without any non numeric characters', () => {
-  const someStringIncludingNonNumericChars = '19660201-1212';
-  const result = caseHelper.stripNonNumericalCharacters(someStringIncludingNonNumericChars);
-  expect(result).toBe('196602011212');
-});
-
-it('Returns an CasePeriod object with UTC timestamps', () => {
-  const result: CasePeriod = caseHelper.getPeriodInMilliseconds(vivaApplication);
-  expect(result).toEqual({
-    endDate: 1643587200000,
-    startDate: 1640995200000,
+describe('stripNonNumericalCharacters', () => {
+  it('Results in a string without any non numeric characters', () => {
+    const someStringIncludingNonNumericChars = '19660201-1212';
+    const result = caseHelper.stripNonNumericalCharacters(someStringIncludingNonNumericChars);
+    expect(result).toBe('196602011212');
   });
 });
 
-it('Returns an list with CasePerson objects', () => {
-  const result: CasePerson[] = caseHelper.getCasePersonList(vivaCaseWithPersonList);
-  expect(result).toEqual([
-    {
-      personalNumber: '198602132394',
-      firstName: 'Bror',
-      lastName: 'Christiansson',
-      role: 'applicant',
-      hasSigned: false,
-    },
-    {
-      personalNumber: '197904123241',
-      firstName: 'Ulla',
-      lastName: 'Christiansson',
-      role: 'coApplicant',
-      hasSigned: false,
-    },
-    {
-      personalNumber: '200002014233',
-      firstName: 'Lisa',
-      lastName: 'Nilsson',
-      role: 'children',
-    },
-  ]);
+describe('getPeriodInMilliseconds', () => {
+  it('Returns an CasePeriod object with UTC timestamps', () => {
+    const result: CasePeriod = caseHelper.getPeriodInMilliseconds(vivaApplication);
+    expect(result).toEqual({
+      endDate: 1643587200000,
+      startDate: 1640995200000,
+    });
+  });
 });
 
-it('Returns an list with the client only as a single CasePerson object', () => {
-  const result: CasePerson[] = caseHelper.getCasePersonList(vivaCaseClientOnly);
-  expect(result).toEqual([
-    {
-      personalNumber: '198602132394',
-      firstName: 'Bror',
-      lastName: 'Christiansson',
-      role: 'applicant',
-      hasSigned: false,
-    },
-  ]);
+describe('getCasePersonList', () => {
+  it('Returns an list with CasePerson objects', () => {
+    const result: CasePerson[] = caseHelper.getCasePersonList(vivaCaseWithPersonList);
+    expect(result).toEqual([
+      {
+        personalNumber: '198602132394',
+        firstName: 'Bror',
+        lastName: 'Christiansson',
+        role: 'applicant',
+        hasSigned: false,
+      },
+      {
+        personalNumber: '197904123241',
+        firstName: 'Ulla',
+        lastName: 'Christiansson',
+        role: 'coApplicant',
+        hasSigned: false,
+      },
+      {
+        personalNumber: '200002014233',
+        firstName: 'Lisa',
+        lastName: 'Nilsson',
+        role: 'children',
+      },
+    ]);
+  });
+
+  it('Returns an list with the client only as a single CasePerson object', () => {
+    const result: CasePerson[] = caseHelper.getCasePersonList(vivaCaseClientOnly);
+    expect(result).toEqual([
+      {
+        personalNumber: '198602132394',
+        firstName: 'Bror',
+        lastName: 'Christiansson',
+        role: 'applicant',
+        hasSigned: false,
+      },
+    ]);
+  });
 });

--- a/services/viva-ms/test/helpers/populateForm.test.js
+++ b/services/viva-ms/test/helpers/populateForm.test.js
@@ -4,18 +4,14 @@ import populateFormWithVivaChildren, {
 } from '../../src/helpers/populateForm';
 import formTemplate from '../mock/formTemplate.json';
 
+import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
+
 const caseRecurringForm = {
   answers: [],
   encryption: {
     type: 'decrypted',
   },
-  currentPosition: {
-    currentMainStepIndex: 0,
-    index: 0,
-    level: 0,
-    currentMainStep: 1,
-    numberOfMainSteps: 0,
-  },
+  currentPosition: DEFAULT_CURRENT_POSITION,
 };
 
 const repeaterInputFields = [
@@ -147,13 +143,7 @@ const expectedPopulatedFormWithChildren = {
   encryption: {
     type: 'decrypted',
   },
-  currentPosition: {
-    currentMainStepIndex: 0,
-    index: 0,
-    level: 0,
-    currentMainStep: 1,
-    numberOfMainSteps: 0,
-  },
+  currentPosition: DEFAULT_CURRENT_POSITION,
 };
 
 describe('populateChildrenAnswers', () => {

--- a/services/viva-ms/test/helpers/populateForm.test.js
+++ b/services/viva-ms/test/helpers/populateForm.test.js
@@ -14,6 +14,7 @@ const caseRecurringForm = {
     index: 0,
     level: 0,
     currentMainStep: 1,
+    numberOfMainSteps: 0,
   },
 };
 
@@ -151,6 +152,7 @@ const expectedPopulatedFormWithChildren = {
     index: 0,
     level: 0,
     currentMainStep: 1,
+    numberOfMainSteps: 0,
   },
 };
 

--- a/services/viva-ms/test/helpers/populateForm.test.js
+++ b/services/viva-ms/test/helpers/populateForm.test.js
@@ -6,10 +6,12 @@ import formTemplate from '../mock/formTemplate.json';
 
 import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
 
+import { EncryptionType } from '../../src/types/caseItem';
+
 const caseRecurringForm = {
   answers: [],
   encryption: {
-    type: 'decrypted',
+    type: EncryptionType.Decrypted,
   },
   currentPosition: DEFAULT_CURRENT_POSITION,
 };
@@ -141,7 +143,7 @@ const expectedPopulatedFormWithChildren = {
     },
   ],
   encryption: {
-    type: 'decrypted',
+    type: EncryptionType.Decrypted,
   },
   currentPosition: DEFAULT_CURRENT_POSITION,
 };

--- a/services/viva-ms/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva-ms/test/lambdas/createNewVivaCase.test.ts
@@ -31,6 +31,7 @@ const defaultFormProperties = {
     currentMainStepIndex: 0,
     index: 0,
     level: 0,
+    numberOfMainSteps: 0,
   },
   encryption: {
     type: EncryptionType.Decrypted,

--- a/services/viva-ms/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva-ms/test/lambdas/createNewVivaCase.test.ts
@@ -9,6 +9,8 @@ import { getStatusByType } from '../../src/libs/caseStatuses';
 
 import { EncryptionType, CasePersonRole } from '../../src/types/caseItem';
 
+import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
+
 const user = {
   firstName: 'First',
   lastName: 'LastName',
@@ -26,13 +28,7 @@ const readParametersResponse = {
 
 const defaultFormProperties = {
   answers: [],
-  currentPosition: {
-    currentMainStep: 1,
-    currentMainStepIndex: 0,
-    index: 0,
-    level: 0,
-    numberOfMainSteps: 0,
-  },
+  currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
     type: EncryptionType.Decrypted,
   },

--- a/services/viva-ms/test/lambdas/submitApplications.test.ts
+++ b/services/viva-ms/test/lambdas/submitApplications.test.ts
@@ -21,6 +21,7 @@ const form = {
     currentMainStepIndex: 0,
     index: 0,
     level: 0,
+    numberOfMainSteps: 0,
   },
   encryption: {
     type: EncryptionType.Decrypted,

--- a/services/viva-ms/test/lambdas/submitApplications.test.ts
+++ b/services/viva-ms/test/lambdas/submitApplications.test.ts
@@ -7,6 +7,8 @@ import {
 import { EncryptionType } from '../../src/types/caseItem';
 import { VivaApplicationType } from '../../src/types/vivaMyPages';
 
+import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
+
 const newApplicationFormId = 'newApplicationFormId';
 const recurrentFormId = 'recurrentFormId';
 const PK = 'mockPK';
@@ -16,13 +18,7 @@ const postVivaResponseId = 'mockPostResponseId';
 
 const form = {
   answers: [],
-  currentPosition: {
-    currentMainStep: 0,
-    currentMainStepIndex: 0,
-    index: 0,
-    level: 0,
-    numberOfMainSteps: 0,
-  },
+  currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
     type: EncryptionType.Decrypted,
   },

--- a/services/viva-ms/test/lambdas/submitCompletion.test.ts
+++ b/services/viva-ms/test/lambdas/submitCompletion.test.ts
@@ -95,6 +95,7 @@ it('calls postCompletion with form answer containing attachment', async () => {
       currentMainStepIndex: 0,
       index: 0,
       level: 0,
+      numberOfMainSteps: 0,
     },
     encryption: {
       type: EncryptionType.Decrypted,
@@ -134,6 +135,7 @@ it('calls `updateCase` with correct parameters for form id: completionFormId', a
       currentMainStepIndex: 0,
       index: 0,
       level: 0,
+      numberOfMainSteps: 0,
     },
     encryption: {
       type: EncryptionType.Decrypted,

--- a/services/viva-ms/test/lambdas/submitCompletion.test.ts
+++ b/services/viva-ms/test/lambdas/submitCompletion.test.ts
@@ -4,6 +4,8 @@ import { VivaAttachmentCategory } from '../../src/types/vivaMyPages';
 import type { CaseItem, CaseForm } from '../../src/types/caseItem';
 import type { CaseAttachment } from '../../src/helpers/attachment';
 
+import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
+
 const randomCheckFormId = 'randomCheckFormId';
 const completionFormId = 'completionFormId';
 const PK = 'USER#199492921234';
@@ -90,13 +92,7 @@ it('returns false if VADA `postCompletionResponse` is successful but `status` is
 it('calls postCompletion with form answer containing attachment', async () => {
   const form: CaseForm = {
     answers: [],
-    currentPosition: {
-      currentMainStep: 1,
-      currentMainStepIndex: 0,
-      index: 0,
-      level: 0,
-      numberOfMainSteps: 0,
-    },
+    currentPosition: DEFAULT_CURRENT_POSITION,
     encryption: {
       type: EncryptionType.Decrypted,
     },
@@ -130,13 +126,7 @@ it('calls postCompletion with form answer containing attachment', async () => {
 it('calls `updateCase` with correct parameters for form id: completionFormId', async () => {
   const form: CaseForm = {
     answers: [],
-    currentPosition: {
-      currentMainStep: 1,
-      currentMainStepIndex: 0,
-      index: 0,
-      level: 0,
-      numberOfMainSteps: 0,
-    },
+    currentPosition: DEFAULT_CURRENT_POSITION,
     encryption: {
       type: EncryptionType.Decrypted,
     },


### PR DESCRIPTION
## Explain the changes you’ve made
Added `numberOfMainSteps` property for tracking the number of steps that exists in a form

## Explain why these changes are made
Today the application lists all cases as cards in the `CaseOverview` screen in the `Mitt Helsingborg` application. These cards also displays the current form progress. The progress calculation is quite expensive since it also requires forms to be fetched from the backend, even though forms aren't used on that particular screen. The case data also keeps track of the current position in the form, hence adding the total number of main steps doesn't seem that bad.

## Explain your solution
Adding `numberOfMainSteps` as a parameter when updating a case, making it non-required to not break existing api. Defaulting numberOfMainSteps to 0.

Also adding this property when creating a new case and its default values.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `viva-ms`
3. 

## Tested environments

- [x] Your personal AWS environment.
- [] Your local Serverless environment.
