### PR TITLE
refactor:(getapistatus) rewrite lambda to typescript

### DIFF
--- a/services/status-api/serverless.yml
+++ b/services/status-api/serverless.yml
@@ -32,7 +32,7 @@ provider:
 
 functions:
   get:
-    handler: src/lambdas/get.main
+    handler: src/lambdas/getApiStatus.main
     environment:
       message: ''
     events:

--- a/services/status-api/src/lambdas/getApiStatus.ts
+++ b/services/status-api/src/lambdas/getApiStatus.ts
@@ -1,7 +1,13 @@
 import * as response from '../libs/response';
 
-export async function main() {
+import log from '../libs/logs';
+
+export async function getApiStatus() {
   const message = process.env.message || '';
 
   return response.success(200, { message });
 }
+
+export const main = log.wrap(() => {
+  return getApiStatus();
+});

--- a/services/status-api/test/lambdas/getApiStatus.test.ts
+++ b/services/status-api/test/lambdas/getApiStatus.test.ts
@@ -1,4 +1,4 @@
-import { main } from '../../src/lambdas/get';
+import { getApiStatus } from '../../src/lambdas/getApiStatus';
 
 const oldEnvironment = { ...process.env };
 
@@ -28,7 +28,7 @@ it('returns the value in `message` environment variable', async () => {
     isBase64Encoded: false,
   };
 
-  const result = await main();
+  const result = await getApiStatus();
 
   expect(result).toEqual(epectedResult);
 });
@@ -46,7 +46,7 @@ it('returns an empty string if `message` variable is not set', async () => {
     isBase64Encoded: false,
   };
 
-  const result = await main();
+  const result = await getApiStatus();
 
   expect(result).toEqual(expectedResult);
 });


### PR DESCRIPTION
## Explain the changes you’ve made
Rewrite lambda to typescript and changed its name.

## Explain why these changes are made
We want to have our functions written in Typescript instead of Javascript for better troubleshooting and development experience, hence rewriting it to Typescript. 

## How to test

Concrete example:

1. Checkout this branch
2. run `sls deploy` within service folder for `service status-api`
3. Invoken the lambda either in AWS console or in the application by:
    1. Change APP_ENV to production in .env file for the application
    2. Add a value in getApiStatus lambda environment variable `message`
    3. Launch the application and see the api message on the login screen