### PR TITLE
Fix/new application encryption

### DIFF
--- a/services/viva/api/cases/src/lambdas/addCasePerson.ts
+++ b/services/viva/api/cases/src/lambdas/addCasePerson.ts
@@ -79,7 +79,7 @@ function updateCase(params: UpdateCaseParameters): Promise<UpdateCaseAddPersonRe
     },
     ExpressionAttributeValues: {
       ':coApplicant': [coApplicant],
-      ':personalNumberGSI1': coApplicant.personalNumber,
+      ':personalNumberGSI1': `USER#${coApplicant.personalNumber}`,
       ':newForm': form[newApplicationFormId],
     },
     ReturnValues: 'ALL_NEW',

--- a/services/viva/api/cases/test/lambdas/addCasePerson.test.ts
+++ b/services/viva/api/cases/test/lambdas/addCasePerson.test.ts
@@ -34,6 +34,7 @@ const form: CaseForm = {
   ],
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
+    symmetricKeyName: '00000000-0000-0000-0000-000000000000',
     type: EncryptionType.Decrypted,
   },
 };

--- a/services/viva/helpers/createCase.ts
+++ b/services/viva/helpers/createCase.ts
@@ -112,10 +112,10 @@ function getInitialFormAttributes(
   );
 }
 
-function getFormEncryptionAttributes(isCoApplicant: boolean): CaseFormEncryption {
+function getFormEncryptionAttributes(): CaseFormEncryption {
   return {
     type: EncryptionType.Decrypted,
-    ...(isCoApplicant && { symmetricKeyName: uuid.v4() }),
+    symmetricKeyName: uuid.v4(),
   };
 }
 

--- a/services/viva/microservice/src/lambdas/createNewVivaCase.ts
+++ b/services/viva/microservice/src/lambdas/createNewVivaCase.ts
@@ -76,8 +76,7 @@ export async function createNewVivaCase(
     newApplicationRandomCheckFormId,
   ];
 
-  const isCoApplicant = false;
-  const initialFormEncryption = createCaseHelper.getFormEncryptionAttributes(isCoApplicant);
+  const initialFormEncryption = createCaseHelper.getFormEncryptionAttributes();
   const initialFormList = createCaseHelper.getInitialFormAttributes(
     formIdList,
     initialFormEncryption

--- a/services/viva/microservice/src/lambdas/createVivaCase.ts
+++ b/services/viva/microservice/src/lambdas/createVivaCase.ts
@@ -107,8 +107,7 @@ export async function createVivaCase(
   }
 
   const formIdList = [recurringFormId, completionFormId, randomCheckFormId];
-  const isCoApplicant = coApplicant != undefined;
-  const initialFormEncryption = createCaseHelper.getFormEncryptionAttributes(isCoApplicant);
+  const initialFormEncryption = createCaseHelper.getFormEncryptionAttributes();
   const initialFormList = createCaseHelper.getInitialFormAttributes(
     formIdList,
     initialFormEncryption

--- a/services/viva/microservice/src/lambdas/submitCompletion.ts
+++ b/services/viva/microservice/src/lambdas/submitCompletion.ts
@@ -131,8 +131,7 @@ export async function submitCompletion(input: LambdaRequest, dependencies: Depen
     return false;
   }
 
-  const isCoApplicant = false;
-  const initialCompletionFormEncryption = caseHelper.getFormEncryptionAttributes(isCoApplicant);
+  const initialCompletionFormEncryption = caseHelper.getFormEncryptionAttributes();
   const initialCompletionForm = caseHelper.getInitialFormAttributes(
     [currentFormId],
     initialCompletionFormEncryption

--- a/services/viva/microservice/test/helpers/populateForm.test.ts
+++ b/services/viva/microservice/test/helpers/populateForm.test.ts
@@ -7,12 +7,13 @@ import formTemplate from '../mock/formTemplate.json';
 import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
 
 import type { FormField } from '../../src/helpers/populateForm';
-import type { CasePerson } from '../../src/types/caseItem';
+import type { CaseForm, CasePerson } from '../../src/types/caseItem';
 import { EncryptionType, CasePersonRole } from '../../src/types/caseItem';
 
-const caseRecurringForm = {
+const caseRecurringForm: CaseForm = {
   answers: [],
   encryption: {
+    symmetricKeyName: '',
     type: EncryptionType.Decrypted,
   },
   currentPosition: DEFAULT_CURRENT_POSITION,
@@ -99,7 +100,7 @@ const expectedChildrenAnswers = [
   },
 ];
 
-const expectedPopulatedFormWithChildren = {
+const expectedPopulatedFormWithChildren: CaseForm = {
   answers: [
     {
       field: {
@@ -145,6 +146,7 @@ const expectedPopulatedFormWithChildren = {
     },
   ],
   encryption: {
+    symmetricKeyName: '',
     type: EncryptionType.Decrypted,
   },
   currentPosition: DEFAULT_CURRENT_POSITION,

--- a/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
@@ -7,9 +7,12 @@ import {
 } from '../../src/libs/constants';
 import { getStatusByType } from '../../src/libs/caseStatuses';
 
-import { EncryptionType, CasePersonRole } from '../../src/types/caseItem';
+import { EncryptionType, CasePersonRole, CaseForm } from '../../src/types/caseItem';
 
 import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
+
+const mockUuid = '00000000-0000-0000-0000-000000000000';
+jest.mock('uuid', () => ({ v4: () => mockUuid }));
 
 const user = {
   firstName: 'First',
@@ -26,10 +29,11 @@ const readParametersResponse = {
   newApplicationCompletionFormId: '6',
 };
 
-const defaultFormProperties = {
+const defaultFormProperties: CaseForm = {
   answers: [],
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
+    symmetricKeyName: mockUuid,
     type: EncryptionType.Decrypted,
   },
 };

--- a/services/viva/microservice/test/lambdas/createVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createVivaCase.test.ts
@@ -2,12 +2,14 @@ import { CASE_PROVIDER_VIVA, VIVA_CASE_CREATED, NOT_STARTED_VIVA } from '../../s
 import { getStatusByType } from '../../src/libs/caseStatuses';
 
 import { createVivaCase, LambdaRequest, DynamoDbPutParams } from '../../src/lambdas/createVivaCase';
-import { EncryptionType, CasePersonRole } from '../../src/types/caseItem';
+import { EncryptionType, CasePersonRole, CaseForm } from '../../src/types/caseItem';
 import { VivaPersonsPerson, VivaPersonType } from '../../src/types/vivaMyPages';
 import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
 
 jest.useFakeTimers('modern').setSystemTime(1640995200000);
-jest.mock('uuid', () => ({ v4: () => '123abc' }));
+
+const mockUuid = '00000000-0000-0000-0000-000000000000';
+jest.mock('uuid', () => ({ v4: () => mockUuid }));
 
 const user = {
   firstName: 'First',
@@ -24,10 +26,11 @@ const readParametersResponse = {
   newApplicationCompletionFormId: '6',
 };
 
-const defaultFormProperties = {
+const defaultFormProperties: CaseForm = {
   answers: [],
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
+    symmetricKeyName: mockUuid,
     type: EncryptionType.Decrypted,
   },
 };
@@ -37,7 +40,7 @@ const partnerFormProperties = {
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
     type: EncryptionType.Decrypted,
-    symmetricKeyName: '123abc',
+    symmetricKeyName: mockUuid,
   },
 };
 
@@ -79,9 +82,9 @@ it('successfully creates a recurring application case', async () => {
   const expectedParameters = {
     TableName: 'cases',
     Item: {
-      id: '123abc',
+      id: mockUuid,
       PK: `USER#${user.personalNumber}`,
-      SK: 'CASE#123abc',
+      SK: `CASE#${mockUuid}`,
       currentFormId: readParametersResponse.recurringFormId,
       details: {
         period: {
@@ -133,9 +136,9 @@ it('successfully creates a recurring application case with partner', async () =>
   const expectedParameters: DynamoDbPutParams = {
     TableName: 'cases',
     Item: {
-      id: '123abc',
+      id: mockUuid,
       PK: `USER#${user.personalNumber}`,
-      SK: 'CASE#123abc',
+      SK: `CASE#${mockUuid}`,
       GSI1: `USER#${user.personalNumber}`,
       currentFormId: readParametersResponse.recurringFormId,
       details: {

--- a/services/viva/microservice/test/lambdas/setCaseCompletions.test.ts
+++ b/services/viva/microservice/test/lambdas/setCaseCompletions.test.ts
@@ -54,6 +54,7 @@ function getCaseItem(
       abc123: {
         answers: [],
         encryption: {
+          symmetricKeyName: '00000000-0000-0000-0000-000000000000',
           type: EncryptionType.Decrypted,
         },
         currentPosition: {

--- a/services/viva/microservice/test/lambdas/submitApplications.test.ts
+++ b/services/viva/microservice/test/lambdas/submitApplications.test.ts
@@ -4,7 +4,7 @@ import {
   Dependencies,
 } from '../../src/lambdas/submitApplication';
 
-import { EncryptionType } from '../../src/types/caseItem';
+import { CaseForm, EncryptionType } from '../../src/types/caseItem';
 import { VivaApplicationType } from '../../src/types/vivaMyPages';
 import type { CaseDetails } from '../../src/types/caseItem';
 
@@ -17,10 +17,11 @@ const SK = 'mockSK';
 const id = 'mockCaseId';
 const postVivaResponseId = 'mockPostResponseId';
 
-const form = {
+const form: CaseForm = {
   answers: [],
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
+    symmetricKeyName: '00000000-0000-0000-0000-000000000000',
     type: EncryptionType.Decrypted,
   },
 };

--- a/services/viva/microservice/test/lambdas/submitCompletion.test.ts
+++ b/services/viva/microservice/test/lambdas/submitCompletion.test.ts
@@ -11,6 +11,9 @@ const completionFormId = 'completionFormId';
 const PK = 'USER#199492921234';
 const SK = 'CASE#123';
 
+const mockUuid = '00000000-0000-0000-0000-000000000000';
+jest.mock('uuid', () => ({ v4: () => mockUuid }));
+
 function createCase(partialCase: Partial<CaseItem> = {}): CaseItem {
   return {
     id: '123',
@@ -115,6 +118,7 @@ it('calls postCompletion with form answer containing attachment', async () => {
     answers: [],
     currentPosition: DEFAULT_CURRENT_POSITION,
     encryption: {
+      symmetricKeyName: mockUuid,
       type: EncryptionType.Decrypted,
     },
   };
@@ -149,6 +153,7 @@ it('calls `updateCase` with correct parameters for form id: completionFormId', a
     answers: [],
     currentPosition: DEFAULT_CURRENT_POSITION,
     encryption: {
+      symmetricKeyName: mockUuid,
       type: EncryptionType.Decrypted,
     },
   };

--- a/services/viva/microservice/test/lambdas/syncCaseCompletions.test.ts
+++ b/services/viva/microservice/test/lambdas/syncCaseCompletions.test.ts
@@ -50,6 +50,7 @@ const caseToUpdate: CaseItem = {
     abc123: {
       answers: [],
       encryption: {
+        symmetricKeyName: '00000000-0000-0000-0000-000000000000',
         type: EncryptionType.Decrypted,
       },
       currentPosition: {

--- a/services/viva/types/caseItem.ts
+++ b/services/viva/types/caseItem.ts
@@ -138,5 +138,5 @@ export enum EncryptionType {
 
 export interface CaseFormEncryption {
   type: EncryptionType.Decrypted;
-  symmetricKeyName?: string;
+  symmetricKeyName: string;
 }


### PR DESCRIPTION
## Explain the changes you’ve made

* Fixed missing prefix in GSI when adding case person
* Always generate symmetricKeyName, causing all cases/forms to use password/pin-based encryption

## Explain why these changes are made

"Forcing" password encryption removes a lot of complexity by removing device-local-aes-key encryption, and causes encryption with new applications for co-applicants to become a non-issue.

## How to test

Concrete example:

1. Checkout this branch
2. deploy stuff
3. Verify new cases have a symmetricKeyName attribute regardless of type

## Other notes

Might need a complimenting app update. Not sure how this impacts existing cases.
