### PR TITLE
Feat/encryptionKeyId

### DIFF
--- a/services/cases-api/src/helpers/schema.js
+++ b/services/cases-api/src/helpers/schema.js
@@ -23,6 +23,7 @@ const encryptedAnswers = Joi.object({
 
 const encryption = Joi.object({
   type: Joi.string().required(),
+  encryptionKeyId: Joi.string(),
   symmetricKeyName: Joi.string(),
   primes: Joi.object({
     P: Joi.number(),

--- a/services/viva/helpers/createCase.ts
+++ b/services/viva/helpers/createCase.ts
@@ -113,9 +113,11 @@ function getInitialFormAttributes(
 }
 
 function getFormEncryptionAttributes(): CaseFormEncryption {
+  const keyId = uuid.v4();
   return {
     type: EncryptionType.Decrypted,
-    symmetricKeyName: uuid.v4(),
+    symmetricKeyName: keyId,
+    encryptionKeyId: keyId,
   };
 }
 

--- a/services/viva/microservice/test/helpers/createCase.test.ts
+++ b/services/viva/microservice/test/helpers/createCase.test.ts
@@ -140,7 +140,8 @@ describe('getInitialFormAttributes', () => {
 
     const caseEncryption: CaseFormEncryption = {
       type: EncryptionType.Decrypted,
-      symmetricKeyName: 'symmetricKeyName',
+      encryptionKeyId: 'encryptionKeyId',
+      symmetricKeyName: 'encryptionKeyId',
     };
 
     const expectedDefaultValue = {

--- a/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
@@ -34,6 +34,7 @@ const defaultFormProperties: CaseForm = {
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
     symmetricKeyName: mockUuid,
+    encryptionKeyId: mockUuid,
     type: EncryptionType.Decrypted,
   },
 };

--- a/services/viva/microservice/test/lambdas/createVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createVivaCase.test.ts
@@ -31,6 +31,7 @@ const defaultFormProperties: CaseForm = {
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
     symmetricKeyName: mockUuid,
+    encryptionKeyId: mockUuid,
     type: EncryptionType.Decrypted,
   },
 };
@@ -40,6 +41,7 @@ const partnerFormProperties = {
   currentPosition: DEFAULT_CURRENT_POSITION,
   encryption: {
     type: EncryptionType.Decrypted,
+    encryptionKeyId: mockUuid,
     symmetricKeyName: mockUuid,
   },
 };

--- a/services/viva/microservice/test/lambdas/submitCompletion.test.ts
+++ b/services/viva/microservice/test/lambdas/submitCompletion.test.ts
@@ -119,6 +119,7 @@ it('calls postCompletion with form answer containing attachment', async () => {
     currentPosition: DEFAULT_CURRENT_POSITION,
     encryption: {
       symmetricKeyName: mockUuid,
+      encryptionKeyId: mockUuid,
       type: EncryptionType.Decrypted,
     },
   };
@@ -154,6 +155,7 @@ it('calls `updateCase` with correct parameters for form id: completionFormId', a
     currentPosition: DEFAULT_CURRENT_POSITION,
     encryption: {
       symmetricKeyName: mockUuid,
+      encryptionKeyId: mockUuid,
       type: EncryptionType.Decrypted,
     },
   };

--- a/services/viva/types/caseItem.ts
+++ b/services/viva/types/caseItem.ts
@@ -138,5 +138,6 @@ export enum EncryptionType {
 
 export interface CaseFormEncryption {
   type: EncryptionType.Decrypted;
-  symmetricKeyName: string;
+  encryptionKeyId?: string;
+  symmetricKeyName?: string;
 }


### PR DESCRIPTION
## Explain the changes you’ve made

Added a new variable `encryptionKeyId` that works the same as the current `symmetricKeyName`.

## Explain why these changes are made

`symmetricKeyName` has become a misleading name as it no longer has anything to do with symmetric key. Just renaming it will break existing cases however, so we introduce a new variable that will take its place once it has been fully adopted (should only take around 1 case period).

## How to test

Concrete example:

1. Checkout this branch
2. Generate a new case
3. Verify it generates a `encryptionKeyId` variable next to the `symmetricKeyName`, with the same value
