### PR TITLE
Fix/bankid collect response

### DIFF
--- a/libs/errorTransformerFactory.ts
+++ b/libs/errorTransformerFactory.ts
@@ -1,38 +1,80 @@
 import axios, { AxiosError } from 'axios';
+import { AWSError } from 'aws-sdk/lib/error';
+
+interface FactoryError extends Error {
+  status: string;
+  code?: string;
+  detail: string;
+}
 
 interface ErrorTransformer<T> {
-  transform: (error: T) => Error;
+  transform: (error: T) => FactoryError;
+  isErrorType: (error: unknown) => error is T;
 }
 
 const axiosErrorTransformer: ErrorTransformer<AxiosError> = {
-  transform: error => ({
-    status: error?.response?.status.toString() || '500',
-    code: error?.code,
-    name: error?.name,
-    message: error?.message,
-    detail: error.response?.data?.details,
-  }),
+  transform(error) {
+    return {
+      status: error?.response?.status.toString() || '500',
+      code: error?.code,
+      name: error?.name,
+      message: error?.message,
+      detail: error.response?.data?.details,
+    };
+  },
+
+  isErrorType(error: unknown): error is AxiosError {
+    return axios.isAxiosError(error);
+  },
 };
 
-const defaultErrorTransformer: ErrorTransformer<Error> = {
-  transform: (error: Error) => error,
+const awsSDKErrorTransformer: ErrorTransformer<AWSError> = {
+  transform(error) {
+    return {
+      status: error.statusCode?.toString() || '500',
+      message: error.message,
+      name: error.name,
+      code: error.code,
+      detail: error.message,
+    };
+  },
+
+  isErrorType(error: unknown): error is AWSError {
+    return ['AccessDeniedException'].includes(error?.code ?? '');
+  },
+};
+
+const javascriptRuntimeErrorTransformer: ErrorTransformer<TypeError> = {
+  transform(error) {
+    return {
+      status: '500',
+      message: error.message,
+      name: error.name,
+      code: '500',
+      detail: error.message,
+    };
+  },
+
+  isErrorType(error: unknown): error is TypeError {
+    return error instanceof TypeError;
+  },
 };
 
 class ErrorTransformerFactory {
-  error: unknown;
-
-  constructor(error: unknown) {
-    this.error = error;
-  }
-
-  transformError() {
-    if (axios.isAxiosError(this.error)) {
-      return axiosErrorTransformer.transform(this.error);
+  static transformError(error: unknown): Error {
+    if (axiosErrorTransformer.isErrorType(error)) {
+      return axiosErrorTransformer.transform(error);
     }
 
-    if (this.error instanceof Error) {
-      return defaultErrorTransformer.transform(this.error);
+    if (awsSDKErrorTransformer.isErrorType(error)) {
+      return awsSDKErrorTransformer.transform(error);
     }
+
+    if (javascriptRuntimeErrorTransformer.isErrorType(error)) {
+      return javascriptRuntimeErrorTransformer.transform(error);
+    }
+
+    throw new Error('Unknown error type');
   }
 }
 

--- a/libs/errorTransformerFactory.ts
+++ b/libs/errorTransformerFactory.ts
@@ -40,7 +40,7 @@ const awsSDKErrorTransformer: ErrorTransformer<AWSError> = {
   },
 
   isErrorType(error: unknown): error is AWSError {
-    return ['AccessDeniedException'].includes(error?.code ?? '');
+    return ['AccessDeniedException'].includes((error as AWSError)?.code ?? '');
   },
 };
 

--- a/libs/errorTransformerFactory.ts
+++ b/libs/errorTransformerFactory.ts
@@ -7,6 +7,8 @@ interface FactoryError extends Error {
   detail: string;
 }
 
+const defaultStatus = '500';
+
 interface ErrorTransformer<T> {
   transform: (error: T) => FactoryError;
   isErrorType: (error: unknown) => error is T;
@@ -15,7 +17,7 @@ interface ErrorTransformer<T> {
 const axiosErrorTransformer: ErrorTransformer<AxiosError> = {
   transform(error) {
     return {
-      status: error?.response?.status.toString() || '500',
+      status: error?.response?.status.toString() || defaultStatus,
       code: error?.code,
       name: error?.name,
       message: error?.message,
@@ -31,7 +33,7 @@ const axiosErrorTransformer: ErrorTransformer<AxiosError> = {
 const awsSDKErrorTransformer: ErrorTransformer<AWSError> = {
   transform(error) {
     return {
-      status: error.statusCode?.toString() || '500',
+      status: error.statusCode?.toString() || defaultStatus,
       message: error.message,
       name: error.name,
       code: error.code,
@@ -47,10 +49,10 @@ const awsSDKErrorTransformer: ErrorTransformer<AWSError> = {
 const javascriptRuntimeErrorTransformer: ErrorTransformer<TypeError> = {
   transform(error) {
     return {
-      status: '500',
+      status: defaultStatus,
       message: error.message,
       name: error.name,
-      code: '500',
+      code: defaultStatus,
       detail: error.message,
     };
   },

--- a/libs/errorTransformerFactory.ts
+++ b/libs/errorTransformerFactory.ts
@@ -60,22 +60,20 @@ const javascriptRuntimeErrorTransformer: ErrorTransformer<TypeError> = {
   },
 };
 
-class ErrorTransformerFactory {
-  static transformError(error: unknown): Error {
-    if (axiosErrorTransformer.isErrorType(error)) {
-      return axiosErrorTransformer.transform(error);
-    }
-
-    if (awsSDKErrorTransformer.isErrorType(error)) {
-      return awsSDKErrorTransformer.transform(error);
-    }
-
-    if (javascriptRuntimeErrorTransformer.isErrorType(error)) {
-      return javascriptRuntimeErrorTransformer.transform(error);
-    }
-
-    throw new Error('Unknown error type');
+function transformError(error: unknown): Error {
+  if (axiosErrorTransformer.isErrorType(error)) {
+    return axiosErrorTransformer.transform(error);
   }
+
+  if (awsSDKErrorTransformer.isErrorType(error)) {
+    return awsSDKErrorTransformer.transform(error);
+  }
+
+  if (javascriptRuntimeErrorTransformer.isErrorType(error)) {
+    return javascriptRuntimeErrorTransformer.transform(error);
+  }
+
+  throw new Error('Unknown error type');
 }
 
-export default ErrorTransformerFactory;
+export default transformError;

--- a/libs/errorTransformerFactory.ts
+++ b/libs/errorTransformerFactory.ts
@@ -1,0 +1,39 @@
+import axios, { AxiosError } from 'axios';
+
+interface ErrorTransformer<T> {
+  transform: (error: T) => Error;
+}
+
+const axiosErrorTransformer: ErrorTransformer<AxiosError> = {
+  transform: error => ({
+    status: error?.response?.status.toString() || '500',
+    code: error?.code,
+    name: error?.name,
+    message: error?.message,
+    detail: error.response?.data?.details,
+  }),
+};
+
+const defaultErrorTransformer: ErrorTransformer<Error> = {
+  transform: (error: Error) => error,
+};
+
+class ErrorTransformerFactory {
+  error: unknown;
+
+  constructor(error: unknown) {
+    this.error = error;
+  }
+
+  transformError() {
+    if (axios.isAxiosError(this.error)) {
+      return axiosErrorTransformer.transform(this.error);
+    }
+
+    if (this.error instanceof Error) {
+      return defaultErrorTransformer.transform(this.error);
+    }
+  }
+}
+
+export default ErrorTransformerFactory;

--- a/libs/lambdaWrapper.ts
+++ b/libs/lambdaWrapper.ts
@@ -1,0 +1,53 @@
+import { Context } from 'aws-lambda';
+
+import ErrorTransformerFactory from '../libs/errorTransformerFactory';
+import * as response from '../libs/response';
+import log from '../libs/logs';
+
+function httpErrorTransformer<LambdaEvent, LambdaResponse>(
+  lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>
+) {
+  return async (event: LambdaEvent, context: Context) => {
+    try {
+      const result = await lambda(event, context);
+      return result;
+    } catch (error) {
+      const transformedError = new ErrorTransformerFactory(error).transformError();
+
+      throw transformedError;
+    }
+  };
+}
+
+function httpResponseWrapper<LambdaEvent, LambdaResponse>(
+  lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>,
+  type: string
+) {
+  return async (event: LambdaEvent, context: Context) => {
+    try {
+      const result = await lambda(event, context);
+      return response.success(200, {
+        type,
+        attributes: result,
+      });
+    } catch (error) {
+      return response.failure(error);
+    }
+  };
+}
+
+function lambdaWrapper<LambdaEvent, LambdaResponse>(
+  lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>,
+  type: string
+) {
+  return log.wrap(
+    httpResponseWrapper<LambdaEvent, LambdaResponse>(
+      httpErrorTransformer((event, context) => {
+        return lambda(event, context);
+      }),
+      type
+    )
+  );
+}
+
+export default lambdaWrapper;

--- a/libs/lambdaWrapper.ts
+++ b/libs/lambdaWrapper.ts
@@ -12,7 +12,7 @@ function httpErrorTransformer<LambdaEvent, LambdaResponse>(
       const result = await lambda(event, context);
       return result;
     } catch (error) {
-      const transformedError = new ErrorTransformerFactory(error).transformError();
+      const transformedError = ErrorTransformerFactory.transformError(error);
 
       throw transformedError;
     }

--- a/libs/lambdaWrapper.ts
+++ b/libs/lambdaWrapper.ts
@@ -4,7 +4,7 @@ import ErrorTransformerFactory from '../libs/errorTransformerFactory';
 import * as response from '../libs/response';
 import log from '../libs/logs';
 
-function httpErrorTransformer<LambdaEvent, LambdaResponse>(
+function httpErrorWrapper<LambdaEvent, LambdaResponse>(
   lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>
 ) {
   return async (event: LambdaEvent, context: Context) => {
@@ -42,7 +42,7 @@ function lambdaWrapper<LambdaEvent, LambdaResponse>(
 ) {
   return log.wrap(
     httpResponseWrapper<LambdaEvent, LambdaResponse>(
-      httpErrorTransformer((event, context) => {
+      httpErrorWrapper((event, context) => {
         return lambda(event, context);
       }),
       type

--- a/libs/lambdaWrapper.ts
+++ b/libs/lambdaWrapper.ts
@@ -1,6 +1,6 @@
 import { Context } from 'aws-lambda';
 
-import ErrorTransformerFactory from './errorTransformerFactory';
+import transformError from './errorTransformerFactory';
 import * as response from './response';
 import log from './logs';
 
@@ -12,7 +12,7 @@ function httpErrorWrapper<LambdaEvent, LambdaResponse>(
       const result = await lambda(event, context);
       return result;
     } catch (error) {
-      const transformedError = ErrorTransformerFactory.transformError(error);
+      const transformedError = transformError(error);
 
       throw transformedError;
     }

--- a/libs/lambdaWrapper.ts
+++ b/libs/lambdaWrapper.ts
@@ -20,14 +20,12 @@ function httpErrorWrapper<LambdaEvent, LambdaResponse>(
 }
 
 function httpResponseWrapper<LambdaEvent, LambdaResponse>(
-  lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>,
-  type: string
+  lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>
 ) {
   return async (event: LambdaEvent, context: Context) => {
     try {
       const result = await lambda(event, context);
       return response.success(200, {
-        type,
         attributes: result,
       });
     } catch (error) {
@@ -36,16 +34,15 @@ function httpResponseWrapper<LambdaEvent, LambdaResponse>(
   };
 }
 
-function lambdaWrapper<LambdaEvent, LambdaResponse>(
-  lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>,
-  type: string
+function lambdaWrapper<LambdaEvent, LambdaResponse, Dependencies>(
+  lambda: (event: LambdaEvent, dependencies: Dependencies) => Promise<LambdaResponse>,
+  dependencies: Dependencies
 ) {
   return log.wrap(
     httpResponseWrapper<LambdaEvent, LambdaResponse>(
-      httpErrorWrapper((event, context) => {
-        return lambda(event, context);
-      }),
-      type
+      httpErrorWrapper(event => {
+        return lambda(event, dependencies);
+      })
     )
   );
 }

--- a/libs/lambdaWrapper.ts
+++ b/libs/lambdaWrapper.ts
@@ -1,8 +1,8 @@
 import { Context } from 'aws-lambda';
 
-import ErrorTransformerFactory from '../libs/errorTransformerFactory';
-import * as response from '../libs/response';
-import log from '../libs/logs';
+import ErrorTransformerFactory from './errorTransformerFactory';
+import * as response from './response';
+import log from './logs';
 
 function httpErrorWrapper<LambdaEvent, LambdaResponse>(
   lambda: (event: LambdaEvent, context: Context) => Promise<LambdaResponse>

--- a/services/bankid-api/src/lambdas/collect.ts
+++ b/services/bankid-api/src/lambdas/collect.ts
@@ -21,8 +21,10 @@ interface BankIdCollectLambdaRequest {
   orderRef: string;
 }
 
+type BankIdStatus = 'pending' | 'complete' | 'failed';
+
 interface BankIdCollectData {
-  status: string;
+  status: BankIdStatus;
   completionData: {
     user: {
       personalNumber: string;
@@ -38,14 +40,14 @@ interface BankIdCollectResponse {
   data: BankIdCollectData;
 }
 
-interface Dependencies {
+export interface Dependencies {
   sendBankIdCollectRequest: (
     parameters: BankIdCollectLambdaRequest
   ) => Promise<BankIdCollectResponse | undefined>;
   generateAuthorizationCode: (personalNumber: string) => Promise<string | undefined>;
 }
 
-interface LambdaRequest {
+export interface LambdaRequest {
   body: string;
   headers: Record<string, string>;
 }

--- a/services/bankid-api/src/lambdas/collect.ts
+++ b/services/bankid-api/src/lambdas/collect.ts
@@ -131,12 +131,7 @@ export async function collect(input: LambdaRequest, dependencies: Dependencies) 
   );
 
   if (bankIdCollectRequestError) {
-    log.error(
-      'Bank Id Collect request error',
-      'context.awsRequestId',
-      'service-bankid-api-collect-001',
-      bankIdCollectRequestError
-    );
+    log.writeError('Bank Id Collect request error', bankIdCollectRequestError);
     return response.failure(bankIdCollectRequestError, {
       type: 'bankIdCollect',
     });
@@ -161,12 +156,7 @@ export async function collect(input: LambdaRequest, dependencies: Dependencies) 
       dependencies.generateAuthorizationCode(personalNumber ?? '')
     );
     if (generateAuthorizationCodeError) {
-      log.error(
-        'Bank Id Authorization code error',
-        'context.awsRequestId',
-        'service-bankid-api-collect-002',
-        generateAuthorizationCodeError ?? {}
-      );
+      log.writeError('Bank Id Authorization code error', generateAuthorizationCodeError ?? {});
 
       return response.failure(generateAuthorizationCodeError);
     }
@@ -183,7 +173,7 @@ export async function collect(input: LambdaRequest, dependencies: Dependencies) 
   });
 }
 
-export const main = log.wrap(async event => {
+export const main = log.wrap(event => {
   return collect(event, {
     sendBankIdCollectRequest,
     generateAuthorizationCode,

--- a/services/bankid-api/src/lambdas/collect.ts
+++ b/services/bankid-api/src/lambdas/collect.ts
@@ -32,7 +32,7 @@ interface BankIdCollectData {
   };
 }
 
-interface ResponseAttributes extends Partial<BankIdCollectData> {
+export interface ResponseAttributes extends Partial<BankIdCollectData> {
   authorizationCode?: string;
 }
 

--- a/services/bankid-api/src/lambdas/collect.ts
+++ b/services/bankid-api/src/lambdas/collect.ts
@@ -18,13 +18,17 @@ interface BankIdCollectLambdaRequest {
 
 type BankIdStatus = 'pending' | 'complete' | 'failed';
 
+interface User {
+  personalNumber: string;
+}
+
+interface BankIDCompletionData {
+  user: User;
+}
+
 interface BankIdCollectData {
   status: BankIdStatus;
-  completionData: {
-    user: {
-      personalNumber: string;
-    };
-  };
+  completionData: BankIDCompletionData;
 }
 
 export interface FunctionResponse extends Partial<BankIdCollectData> {

--- a/services/bankid-api/src/lambdas/collect.ts
+++ b/services/bankid-api/src/lambdas/collect.ts
@@ -98,7 +98,10 @@ async function sendBankIdCollectRequest(
   return collectResult;
 }
 
-export async function collect(input: FunctionInput, dependencies: Dependencies) {
+export async function collect(
+  input: FunctionInput,
+  dependencies: Dependencies
+): Promise<FunctionResponse> {
   const { body, headers } = input;
   const { orderRef } = JSON.parse(body);
 
@@ -130,12 +133,8 @@ export async function collect(input: FunctionInput, dependencies: Dependencies) 
   return responseAttributes;
 }
 
-export const main = lambdaWrapper<FunctionInput, FunctionResponse>(
-  event =>
-    collect(event, {
-      sendBankIdCollectRequest: sendBankIdCollectRequest,
-      generateAuthorizationCode: generateAuthorizationCode,
-      sendBankIdStatusCompleteEvent: putEvent,
-    }),
-  'bankId.collect'
-);
+export const main = lambdaWrapper(collect, {
+  sendBankIdCollectRequest: sendBankIdCollectRequest,
+  generateAuthorizationCode: generateAuthorizationCode,
+  sendBankIdStatusCompleteEvent: putEvent,
+});

--- a/services/bankid-api/test/lambdas/collect.test.ts
+++ b/services/bankid-api/test/lambdas/collect.test.ts
@@ -8,34 +8,115 @@ const mockUser = {
   personalNumber: '199009111111',
 };
 const mockAuthorizationCode = '123456';
+const mockBody = JSON.stringify({ orderRef: '123456' });
+const mockHeaders = { 'User-Agent': 'MittHelsingborg/1.3.0/ios/15.0' };
 
-function createDependencies(): Dependencies {
+function createDependencies(partialDependencies: Partial<Dependencies> = {}): Dependencies {
   return {
     sendBankIdCollectRequest: () =>
       Promise.resolve({ data: { status: 'complete', completionData: { user: mockUser } } }),
     generateAuthorizationCode: () => Promise.resolve(mockAuthorizationCode),
+    sendBankIdStatusCompleteEvent: () => Promise.resolve(),
+    ...partialDependencies,
   };
 }
 
 function createInput(): LambdaRequest {
   return {
-    body: JSON.stringify({ orderRef: '123456' }),
-    headers: {},
+    body: mockBody,
+    headers: mockHeaders,
   };
 }
 
-it('returns collect data successfully', async () => {
-  const result = await collect(createInput(), createDependencies());
-
-  expect(result).toEqual(
-    response.success(200, {
-      type: 'bankIdCollect',
-      attributes: {
-        status: 'complete',
-        completionData: {
-          user: mockUser,
-        },
+function createSuccessResponse(
+  partialBankIdResponse: Partial<{
+    authorizationCode: string;
+    status: string;
+  }> = {}
+) {
+  return response.success(200, {
+    type: 'bankIdCollect',
+    attributes: {
+      ...(partialBankIdResponse.authorizationCode && { authorizationCode: mockAuthorizationCode }),
+      status: partialBankIdResponse.status ?? 'pending',
+      completionData: {
+        user: mockUser,
       },
+    },
+  });
+}
+
+function createFailureResponse(error: { status: number; message: string }) {
+  return response.failure(error, {
+    type: 'bankIdCollect',
+  });
+}
+
+it('returns collect data successfully for bankId status pending', async () => {
+  const sendBankIdStatusCompleteEventMock = jest.fn();
+
+  const result = await collect(
+    createInput(),
+    createDependencies({
+      sendBankIdCollectRequest: () =>
+        Promise.resolve({ data: { status: 'pending', completionData: { user: mockUser } } }),
+      sendBankIdStatusCompleteEvent: sendBankIdStatusCompleteEventMock,
     })
   );
+
+  expect(result).toEqual(createSuccessResponse());
+  expect(sendBankIdStatusCompleteEventMock).not.toHaveBeenCalled();
+});
+
+it('returns collect data successfully for bankId status complete', async () => {
+  const sendBankIdStatusCompleteEventMock = jest.fn();
+
+  const result = await collect(
+    createInput(),
+    createDependencies({
+      sendBankIdStatusCompleteEvent: sendBankIdStatusCompleteEventMock,
+    })
+  );
+
+  expect(result).toEqual(
+    createSuccessResponse({
+      authorizationCode: mockAuthorizationCode,
+      status: 'complete',
+    })
+  );
+  expect(sendBankIdStatusCompleteEventMock).toHaveBeenCalled();
+});
+
+it('returns failure for failing sendBankIdCollectRequest', async () => {
+  const mockErrorObject = {
+    status: 404,
+    message: 'not found',
+  };
+  const sendBankIdCollectRequestMock = jest.fn().mockRejectedValueOnce(mockErrorObject);
+
+  const result = await collect(
+    createInput(),
+    createDependencies({
+      sendBankIdCollectRequest: sendBankIdCollectRequestMock,
+    })
+  );
+
+  expect(result).toEqual(createFailureResponse(mockErrorObject));
+});
+
+it('returns failure for failing generateAuthorizationCode request', async () => {
+  const mockErrorObject = {
+    status: 500,
+    message: 'internal server error',
+  };
+  const generateAuthorizationCodeMock = jest.fn().mockRejectedValueOnce(mockErrorObject);
+
+  const result = await collect(
+    createInput(),
+    createDependencies({
+      generateAuthorizationCode: generateAuthorizationCodeMock,
+    })
+  );
+
+  expect(result).toEqual(createFailureResponse(mockErrorObject));
 });

--- a/services/bankid-api/test/lambdas/collect.test.ts
+++ b/services/bankid-api/test/lambdas/collect.test.ts
@@ -1,0 +1,41 @@
+import { collect } from '../../src/lambdas/collect';
+
+import * as response from '../../../../libs/response';
+
+import type { LambdaRequest, Dependencies } from '../../src/lambdas/collect';
+
+const mockUser = {
+  personalNumber: '199009111111',
+};
+const mockAuthorizationCode = '123456';
+
+function createDependencies(): Dependencies {
+  return {
+    sendBankIdCollectRequest: () =>
+      Promise.resolve({ data: { status: 'complete', completionData: { user: mockUser } } }),
+    generateAuthorizationCode: () => Promise.resolve(mockAuthorizationCode),
+  };
+}
+
+function createInput(): LambdaRequest {
+  return {
+    body: JSON.stringify({ orderRef: '123456' }),
+    headers: {},
+  };
+}
+
+it('returns collect data successfully', async () => {
+  const result = await collect(createInput(), createDependencies());
+
+  expect(result).toEqual(
+    response.success(200, {
+      type: 'bankIdCollect',
+      attributes: {
+        status: 'complete',
+        completionData: {
+          user: mockUser,
+        },
+      },
+    })
+  );
+});

--- a/services/bankid-api/test/lambdas/collect.test.ts
+++ b/services/bankid-api/test/lambdas/collect.test.ts
@@ -1,8 +1,6 @@
 import { collect } from '../../src/lambdas/collect';
 
-import * as response from '../../../../libs/response';
-
-import type { LambdaRequest, Dependencies } from '../../src/lambdas/collect';
+import type { FunctionInput, Dependencies } from '../../src/lambdas/collect';
 
 const mockUser = {
   personalNumber: '199009111111',
@@ -21,35 +19,11 @@ function createDependencies(partialDependencies: Partial<Dependencies> = {}): De
   };
 }
 
-function createInput(): LambdaRequest {
+function createInput(): FunctionInput {
   return {
     body: mockBody,
     headers: mockHeaders,
   };
-}
-
-function createSuccessResponse(
-  partialBankIdResponse: Partial<{
-    authorizationCode: string;
-    status: string;
-  }> = {}
-) {
-  return response.success(200, {
-    type: 'bankIdCollect',
-    attributes: {
-      ...(partialBankIdResponse.authorizationCode && { authorizationCode: mockAuthorizationCode }),
-      status: partialBankIdResponse.status ?? 'pending',
-      completionData: {
-        user: mockUser,
-      },
-    },
-  });
-}
-
-function createFailureResponse(error: { status: number; message: string }) {
-  return response.failure(error, {
-    type: 'bankIdCollect',
-  });
 }
 
 it('returns collect data successfully for bankId status pending', async () => {
@@ -64,7 +38,12 @@ it('returns collect data successfully for bankId status pending', async () => {
     })
   );
 
-  expect(result).toEqual(createSuccessResponse());
+  expect(result).toEqual({
+    completionData: {
+      user: mockUser,
+    },
+    status: 'pending',
+  });
   expect(sendBankIdStatusCompleteEventMock).not.toHaveBeenCalled();
 });
 
@@ -78,45 +57,12 @@ it('returns collect data successfully for bankId status complete', async () => {
     })
   );
 
-  expect(result).toEqual(
-    createSuccessResponse({
-      authorizationCode: mockAuthorizationCode,
-      status: 'complete',
-    })
-  );
+  expect(result).toEqual({
+    authorizationCode: mockAuthorizationCode,
+    completionData: {
+      user: mockUser,
+    },
+    status: 'complete',
+  });
   expect(sendBankIdStatusCompleteEventMock).toHaveBeenCalled();
-});
-
-it('returns failure for failing sendBankIdCollectRequest', async () => {
-  const mockErrorObject = {
-    status: 404,
-    message: 'not found',
-  };
-  const sendBankIdCollectRequestMock = jest.fn().mockRejectedValueOnce(mockErrorObject);
-
-  const result = await collect(
-    createInput(),
-    createDependencies({
-      sendBankIdCollectRequest: sendBankIdCollectRequestMock,
-    })
-  );
-
-  expect(result).toEqual(createFailureResponse(mockErrorObject));
-});
-
-it('returns failure for failing generateAuthorizationCode request', async () => {
-  const mockErrorObject = {
-    status: 500,
-    message: 'internal server error',
-  };
-  const generateAuthorizationCodeMock = jest.fn().mockRejectedValueOnce(mockErrorObject);
-
-  const result = await collect(
-    createInput(),
-    createDependencies({
-      generateAuthorizationCode: generateAuthorizationCodeMock,
-    })
-  );
-
-  expect(result).toEqual(createFailureResponse(mockErrorObject));
 });


### PR DESCRIPTION
## Explain the changes you’ve made
Fix faulty api gateway response causing api gateway to default to 502 

## Explain why these changes are made
The MittHelsingborg application thought that status code 502 is time out, but in fact it is a default status code from apigateway. This caused the application to retry the collect lambda unlimited times

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service bankid-api`
3. try the collect lambda from the application
