### PR TITLE
test: use consistent test command for individual services

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,10 +2,6 @@ cwd=$(pwd)
 
 pushd ../
 
-if [ $# -eq 0 ]; then
-    yarn test $cwd
-else
-    yarn test $@
-fi
+yarn test $cwd $@
 
 popd

--- a/services/bankid-api/package.json
+++ b/services/bankid-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "../../scripts/test.sh"
   },
   "keywords": [],
   "author": "Helsingborg Stad",

--- a/services/cases-api/package.json
+++ b/services/cases-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "cd ../../ && node node_modules/.bin/jest cases-api"
+    "test": "../../scripts/test.sh"
   },
   "keywords": [],
   "author": "Helsingborg Stad",

--- a/services/navet-ms/package.json
+++ b/services/navet-ms/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "poll.js",
   "scripts": {
-    "test": "cd ../../ && node node_modules/.bin/jest navet-ms"
+    "test": "../../scripts/test.sh"
   },
   "keywords": [],
   "author": "Helsingborg Stad",

--- a/services/status-api/package.json
+++ b/services/status-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "cd ../../ && node node_modules/.bin/jest status-api"
+    "test": "../../scripts/test.sh"
   },
   "keywords": [],
   "author": "Helsingborg Stad",

--- a/services/users-api/package.json
+++ b/services/users-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "cd ../../ && node node_modules/.bin/jest users-api"
+    "test": "../../scripts/test.sh"
   },
   "keywords": [],
   "author": "Helsingborg Stad",

--- a/services/version-api/package.json
+++ b/services/version-api/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "cd ../../ && node node_modules/.bin/jest version-api"
+    "test": "../../scripts/test.sh"
   },
   "author": "Helsingborg Stad",
   "license": "MIT",

--- a/services/viva/api/cases/package.json
+++ b/services/viva/api/cases/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "cd ../../../../ && node node_modules/.bin/jest viva/api/cases"
+    "test": "../../../../scripts/test.sh"
   },
   "keywords": [],
   "author": "Helsingborg Stad",


### PR DESCRIPTION
## Explain the changes you’ve made

Use the same `test.sh` script for each individual services' `yarn test` command.

## Explain why these changes are made

Provide a unified test experience when running individual service tests. Test script also correctly pipes arguments to `jest`.

## How to test

Concrete example:

1. Checkout this branch
2. Run `yarn test` inside a service dir and verify it works as expected.
3. Verify tests overall are not broken.

