### PR TITLE
fix: only use array answers for populating previous answers

### DIFF
--- a/libs/formAnswers.d.ts
+++ b/libs/formAnswers.d.ts
@@ -12,9 +12,9 @@ export function formatAnswer(
   value: any;
 };
 export function mergeAnswers(previousAnswers: any, newAnswers: any): any[];
-export function populateFormWithPreviousCaseAnswers(
+export function populateFormWithPreviousCaseAnswers({
   forms: any,
   applicants: any,
   formTemplates: any,
-  previousForms: any
-): Record<string, never>;
+  previousForms: any,
+}): Record<string, never>;

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -167,7 +167,9 @@ export function populateFormWithPreviousCaseAnswers(
   Object.keys(forms).forEach(formId => {
     const caseFormTemplate = formTemplates?.[formId] || {};
 
-    const previousAnswers = previousForms?.[formId]?.answers || [];
+    const previousCaseAnswers = previousForms?.[formId]?.answers;
+    const previousAreEncrypted = !Array.isArray(previousCaseAnswers);
+    const previousAnswers = previousAreEncrypted ? [] : previousCaseAnswers;
 
     const formFields = getFormFieldsWithLoadPreviousAttribute(caseFormTemplate);
 

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -168,8 +168,8 @@ export function populateFormWithPreviousCaseAnswers(
     const caseFormTemplate = formTemplates?.[formId] || {};
 
     const previousCaseAnswers = previousForms?.[formId]?.answers;
-    const previousAreEncrypted = !Array.isArray(previousCaseAnswers);
-    const previousAnswers = previousAreEncrypted ? [] : previousCaseAnswers;
+    const isPreviousFormEncrypted = !Array.isArray(previousCaseAnswers);
+    const previousAnswers = isPreviousFormEncrypted ? [] : previousCaseAnswers;
 
     const formFields = getFormFieldsWithLoadPreviousAttribute(caseFormTemplate);
 

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -156,12 +156,12 @@ export function mergeAnswers(previousAnswers, newAnswers) {
   );
 }
 
-export function populateFormWithPreviousCaseAnswers(
+export function populateFormWithPreviousCaseAnswers({
   forms,
   applicants,
   formTemplates,
-  previousForms
-) {
+  previousForms,
+}) {
   const populatedForms = {};
 
   Object.keys(forms).forEach(formId => {

--- a/services/cases-api/src/lambdas/createCase.js
+++ b/services/cases-api/src/lambdas/createCase.js
@@ -73,12 +73,12 @@ export async function main(event, context) {
 
   const applicants = [{ role: 'applicant', ...user }];
 
-  const prePopulatedForms = populateFormWithPreviousCaseAnswers(
-    initialForms,
+  const prePopulatedForms = populateFormWithPreviousCaseAnswers({
+    forms: initialForms,
     applicants,
     formTemplates,
-    previousCase?.forms || {}
-  );
+    previousForms: previousCase?.forms || {},
+  });
 
   const persons = [
     {

--- a/services/viva/api/cases/src/lambdas/addCasePerson.ts
+++ b/services/viva/api/cases/src/lambdas/addCasePerson.ts
@@ -135,12 +135,12 @@ export async function addCasePerson(input: LambdaRequest, dependencies: Dependen
     CaseForm
   >;
 
-  const formWithCoApplicant: Record<string, CaseForm> = dependencies.populateForm(
-    caseForm,
-    [coApplicant],
+  const formWithCoApplicant: Record<string, CaseForm> = dependencies.populateForm({
+    forms: caseForm,
+    applicants: [coApplicant],
     formTemplates,
-    {}
-  );
+    previousForms: {},
+  });
 
   const updateCaseResult = await dependencies.updateCase({
     caseKeys,

--- a/services/viva/microservice/src/lambdas/createNewVivaCase.ts
+++ b/services/viva/microservice/src/lambdas/createNewVivaCase.ts
@@ -112,12 +112,12 @@ export async function createNewVivaCase(
 
   const formTemplates = await dependencies.getTemplates(formIdList);
 
-  const prePopulatedForms: Record<string, CaseForm> = populateFormWithPreviousCaseAnswers(
-    initialFormList,
-    extendedCasePersonList,
+  const prePopulatedForms: Record<string, CaseForm> = populateFormWithPreviousCaseAnswers({
+    forms: initialFormList,
+    applicants: extendedCasePersonList,
     formTemplates,
-    {}
-  );
+    previousForms: {},
+  });
 
   const newVivaCaseItem: CaseItem = {
     id,

--- a/services/viva/microservice/src/lambdas/createVivaCase.ts
+++ b/services/viva/microservice/src/lambdas/createVivaCase.ts
@@ -124,12 +124,12 @@ export async function createVivaCase(
   const formTemplates = await dependencies.getFormTemplates(formIdList);
   const lastUpdatedCase = await dependencies.getLastUpdatedCase(PK);
 
-  const prePopulatedForms = populateFormWithPreviousCaseAnswers(
-    initialFormList,
-    extendedPersonList,
+  const prePopulatedForms = populateFormWithPreviousCaseAnswers({
+    forms: initialFormList,
+    applicants: extendedPersonList,
     formTemplates,
-    lastUpdatedCase?.forms
-  ) as Record<string, CaseForm>;
+    previousForms: lastUpdatedCase?.forms,
+  }) as Record<string, CaseForm>;
 
   const vivaChildrenList = createCaseHelper.getVivaChildren(casePersonList);
   if (vivaChildrenList.length > 0) {


### PR DESCRIPTION
## Explain the changes you’ve made

Check if previous answers is array (i.e. not encrypted) before using for pre-populating new case.

## Explain why these changes are made

Some edge-cases have previous cases with decisions but with encrypted answers - pre-population then crashes for any new cases.

## How to test

Concrete example:

1. Checkout this branch
2. Have a case with decisions but replace the answers of the form with encrypted answers:

```json
"a1ce65a0-3d7c-11ec-801e-2db8270ee167": {
   "answers": {
    "encryptedAnswers": "abcdefg"
   },
   "currentPosition": {
    "currentMainStep": 4,
    "currentMainStepIndex": 3,
    "index": 3,
    "level": 0,
    "numberOfMainSteps": 9
   },
   "encryption": {
    "encryptionKeyId": "2fa16de5-6557-4f35-bb36-3a475fd9136d",
    "symmetricKeyName": "2fa16de5-6557-4f35-bb36-3a475fd9136d",
    "type": "password"
   }
  }
```

3. Login/refresh to try to create a new case and verify it is created as expected (with no pre-populated answers).