### PR TITLE
feat(createnewvivacase): only allowed users to create new viva case

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,6 +44,9 @@
     },
     "version": {
       "envsKeyName": "/versionEnvs/dev"
+    },
+    "vivaNewApplication": {
+      "envsKeyName": "/vivaNewApplicationEnvs/dev"
     }
   },
   "test": {
@@ -91,6 +94,9 @@
     },
     "version": {
       "envsKeyName": "/versionEnvs/test"
+    },
+    "vivaNewApplication": {
+      "envsKeyName": "/vivaNewApplicationEnvs/test"
     }
   },
   "stage": {
@@ -138,6 +144,9 @@
     },
     "version": {
       "envsKeyName": "/versionEnvs/stage"
+    },
+    "vivaNewApplication": {
+      "envsKeyName": "/vivaNewApplicationEnvs/stage"
     }
   },
   "release": {
@@ -185,6 +194,9 @@
     },
     "version": {
       "envsKeyName": "/versionEnvs/release"
+    },
+    "vivaNewApplication": {
+      "envsKeyName": "/vivaNewApplicationEnvs/release"
     }
   },
   "prod": {
@@ -232,6 +244,9 @@
     },
     "version": {
       "envsKeyName": "/versionEnvs/prod"
+    },
+    "vivaNewApplication": {
+      "envsKeyName": "/vivaNewApplicationEnvs/prod"
     }
   }
 }

--- a/libs/config.js
+++ b/libs/config.js
@@ -49,6 +49,9 @@ const stageConfigs = {
     version: {
       envsKeyName: '/versionEnvs/dev',
     },
+    vivaNewApplication: {
+      envsKeyName: '/vivaNewApplicationEnvs/dev',
+    },
   },
   test: {
     auth: {
@@ -95,6 +98,9 @@ const stageConfigs = {
     },
     version: {
       envsKeyName: '/versionEnvs/test',
+    },
+    vivaNewApplication: {
+      envsKeyName: '/vivaNewApplicationEnvs/test',
     },
   },
   stage: {
@@ -143,6 +149,9 @@ const stageConfigs = {
     version: {
       envsKeyName: '/versionEnvs/stage',
     },
+    vivaNewApplication: {
+      envsKeyName: '/vivaNewApplicationEnvs/stage',
+    },
   },
   prod: {
     auth: {
@@ -190,6 +199,9 @@ const stageConfigs = {
     version: {
       envsKeyName: '/versionEnvs/prod',
     },
+    vivaNewApplication: {
+      envsKeyName: '/vivaNewApplicationEnvs/prod',
+    },
   },
   release: {
     auth: {
@@ -236,6 +248,9 @@ const stageConfigs = {
     },
     version: {
       envsKeyName: '/versionEnvs/release',
+    },
+    vivaNewApplication: {
+      envsKeyName: '/vivaNewApplicationEnvs/release',
     },
   },
 };

--- a/services/viva/microservice/serverless.yml
+++ b/services/viva/microservice/serverless.yml
@@ -37,6 +37,7 @@ provider:
           Resource:
             - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../../config.json):${self:custom.stage}.vada.envsKeyName}'
             - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../../config.json):${self:custom.stage}.cases.providers.viva.envsKeyName}'
+            - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${file(../../../config.json):${self:custom.stage}.vivaNewApplication.envsKeyName}'
 
         - Effect: Allow
           Action:

--- a/services/viva/microservice/src/lambdas/createNewVivaCase.ts
+++ b/services/viva/microservice/src/lambdas/createNewVivaCase.ts
@@ -157,6 +157,6 @@ export const main = log.wrap(event => {
     readParams: params.read,
     getUserCasesCount,
     getTemplates: getFormTemplates,
-    getApprovedNewApplicationUsers: getApprovedNewApplicationUsers,
+    getApprovedNewApplicationUsers,
   });
 });

--- a/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
@@ -12,7 +12,6 @@ import { EncryptionType, CasePersonRole, CaseForm } from '../../src/types/caseIt
 import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
 
 import type { Dependencies } from '../../src/lambdas/createNewVivaCase';
-import createCase from '../../src/helpers/createCase';
 
 const mockUuid = '00000000-0000-0000-0000-000000000000';
 jest.mock('uuid', () => ({ v4: () => mockUuid }));

--- a/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
@@ -138,3 +138,18 @@ it('stops execution when users personal number is not approved for new applicati
   expect(result).toBe(true);
   expect(createCaseMock).toHaveBeenCalledTimes(0);
 });
+
+it('stops execution when allowed users personal number array is empty', async () => {
+  const createCaseMock = jest.fn().mockResolvedValueOnce(undefined);
+
+  const result = await createNewVivaCase(
+    lambdaInput,
+    createDependencies({
+      createCase: createCaseMock,
+      getApprovedNewApplicationUsers: () => Promise.resolve([]),
+    })
+  );
+
+  expect(result).toBe(true);
+  expect(createCaseMock).toHaveBeenCalledTimes(0);
+});

--- a/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
@@ -11,6 +11,9 @@ import { EncryptionType, CasePersonRole, CaseForm } from '../../src/types/caseIt
 
 import { DEFAULT_CURRENT_POSITION } from '../../src/helpers/constants';
 
+import type { Dependencies } from '../../src/lambdas/createNewVivaCase';
+import createCase from '../../src/helpers/createCase';
+
 const mockUuid = '00000000-0000-0000-0000-000000000000';
 jest.mock('uuid', () => ({ v4: () => mockUuid }));
 
@@ -44,6 +47,19 @@ const lambdaInput = {
     user,
   },
 };
+
+const getApprovedNewApplicationUsers = ['199402011234'];
+
+function createDependencies(partialDependencies: Partial<Dependencies> = {}) {
+  return {
+    readParams: () => Promise.resolve(readParametersResponse),
+    getTemplates: () => Promise.resolve({}),
+    getUserCasesCount: () => Promise.resolve({ Count: 0 }),
+    getApprovedNewApplicationUsers: () => Promise.resolve(getApprovedNewApplicationUsers),
+    createCase: () => Promise.resolve({ id: '123' }),
+    ...partialDependencies,
+  };
+}
 
 it('successfully creates a new application case', async () => {
   const expectedParameters = {
@@ -79,12 +95,12 @@ it('successfully creates a new application case', async () => {
 
   const createCaseMock = jest.fn().mockResolvedValueOnce({ id: '123' });
 
-  const result = await createNewVivaCase(lambdaInput, {
-    createCase: createCaseMock,
-    readParams: () => Promise.resolve(readParametersResponse),
-    getTemplates: () => Promise.resolve({}),
-    getUserCasesCount: () => Promise.resolve({ Count: 0 }),
-  });
+  const result = await createNewVivaCase(
+    lambdaInput,
+    createDependencies({
+      createCase: createCaseMock,
+    })
+  );
 
   expect(result).toBe(true);
   expect(createCaseMock).toHaveBeenCalledWith(
@@ -97,12 +113,28 @@ it('successfully creates a new application case', async () => {
 it('stops execution when user cases exists', async () => {
   const createCaseMock = jest.fn().mockResolvedValueOnce(undefined);
 
-  const result = await createNewVivaCase(lambdaInput, {
-    createCase: createCaseMock,
-    readParams: () => Promise.resolve(readParametersResponse),
-    getTemplates: () => Promise.resolve({}),
-    getUserCasesCount: () => Promise.resolve({ Count: 1 }),
-  });
+  const result = await createNewVivaCase(
+    lambdaInput,
+    createDependencies({
+      createCase: createCaseMock,
+      getUserCasesCount: () => Promise.resolve({ Count: 1 }),
+    })
+  );
+
+  expect(result).toBe(true);
+  expect(createCaseMock).toHaveBeenCalledTimes(0);
+});
+
+it('stops execution when users personal number is not approved for new application', async () => {
+  const createCaseMock = jest.fn().mockResolvedValueOnce(undefined);
+
+  const result = await createNewVivaCase(
+    lambdaInput,
+    createDependencies({
+      createCase: createCaseMock,
+      getApprovedNewApplicationUsers: () => Promise.resolve(['111111']),
+    })
+  );
 
   expect(result).toBe(true);
   expect(createCaseMock).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
## Explain the changes you’ve made
Only allow approved new application users to create a new viva case

## Explain why these changes are made
There is a need to only test new application functionality on specific users, hence adding this check.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service viva`
3. Add a personal number in SSM (https://github.com/helsingborg-stad/helsingborg-io-sls-resources/pull/109)
