### PR TITLE
Feat/metrics-service-lib

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,9 @@ module.exports = {
       plugins: ['@typescript-eslint'],
       parser: '@typescript-eslint/parser',
       extends: ['plugin:@typescript-eslint/recommended', 'prettier'],
+      rules: {
+        '@typescript-eslint/consistent-type-imports': 'warn',
+      },
     },
   ],
 };

--- a/services/metrics-api/src/helpers/formats/ebnf.test.ts
+++ b/services/metrics-api/src/helpers/formats/ebnf.test.ts
@@ -1,0 +1,162 @@
+import { ebnf } from '.';
+import type { MaybeMetricMeta, Metric } from '../metrics.types';
+
+describe('EBNF adapter', () => {
+  it('handles simple metric', () => {
+    const metric: Metric = {
+      name: 'hello',
+      values: [{ value: 123 }],
+    };
+
+    const result = ebnf.format(metric);
+
+    expect(result).toBe('hello 123');
+  });
+
+  it('handles floats', () => {
+    const metric: Metric = {
+      name: 'hello',
+      values: [{ value: 420.1337 }],
+    };
+
+    const result = ebnf.format(metric);
+
+    expect(result).toBe('hello 420.1337');
+  });
+
+  it('shows help', () => {
+    const metric: Metric = {
+      name: 'myMetric',
+      values: [{ value: 1 }],
+      help: 'lorem ipsum dolar sitem.',
+    };
+
+    const result = ebnf.format(metric);
+    const lines = result.split('\n');
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe('# HELP myMetric lorem ipsum dolar sitem.');
+  });
+
+  it('shows type', () => {
+    const metric: Metric = {
+      name: 'myMetric',
+      values: [{ value: 1 }],
+      type: 'counter',
+    };
+
+    const result = ebnf.format(metric);
+    const lines = result.split('\n');
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe('# TYPE myMetric counter');
+  });
+
+  it('handles labels', () => {
+    const metric: Metric<{ A: string; B: string }> = {
+      name: 'hello',
+      values: [
+        {
+          value: 1,
+          meta: {
+            A: 'lorem',
+            B: 'ipsum',
+          },
+        },
+      ],
+    };
+
+    const result = ebnf.format(metric);
+
+    expect(result).toBe('hello{A="lorem",B="ipsum"} 1');
+  });
+
+  it('handles multiple metrics', () => {
+    const metrics: Metric<MaybeMetricMeta>[] = [
+      {
+        name: 'hello',
+        values: [{ value: 123 }],
+      },
+      {
+        name: 'myMetric1',
+        values: [{ value: 3.1415 }],
+        help: 'short version of PI.',
+        type: 'gauge',
+      },
+      {
+        name: 'myMetric2',
+        values: [{ value: 1.41421 }],
+        help: 'Square root of 2 probably.',
+        type: 'histogram',
+      },
+      {
+        name: 'myMetric3',
+        values: [
+          {
+            value: 2.71828,
+            meta: {
+              source: 'wikipedia',
+              verified: 'false',
+            },
+          },
+        ],
+        help: "Approximation of Euler's number.",
+        type: 'untyped',
+      },
+    ];
+
+    const expected = [
+      'hello 123',
+      '',
+      '# HELP myMetric1 short version of PI.',
+      '# TYPE myMetric1 gauge',
+      'myMetric1 3.1415',
+      '',
+      '# HELP myMetric2 Square root of 2 probably.',
+      '# TYPE myMetric2 histogram',
+      'myMetric2 1.41421',
+      '',
+      "# HELP myMetric3 Approximation of Euler's number.",
+      '# TYPE myMetric3 untyped',
+      'myMetric3{source="wikipedia",verified="false"} 2.71828',
+    ].join('\n');
+
+    const result = ebnf.formatMultiple(metrics);
+
+    expect(result).toBe(expected);
+  });
+
+  it('produces nothing for a metric without values', () => {
+    const metric: Metric = {
+      name: 'hello',
+      values: [],
+    };
+
+    const result = ebnf.format(metric);
+
+    expect(result).toBe('');
+  });
+
+  it('ignores empty metrics for multiple metrics', () => {
+    const metrics: Metric[] = [
+      {
+        name: 'A',
+        values: [{ value: 1 }],
+      },
+      {
+        name: 'B',
+        values: [],
+      },
+      {
+        name: 'C',
+        values: [{ value: 3 }],
+      },
+    ];
+
+    const expected = ['A 1', '', 'C 3'].join('\n');
+
+    const result = ebnf.formatMultiple(metrics);
+
+    expect(result).toBe(expected);
+  });
+});

--- a/services/metrics-api/src/helpers/formats/ebnf.test.ts
+++ b/services/metrics-api/src/helpers/formats/ebnf.test.ts
@@ -1,4 +1,6 @@
 import { ebnf } from '.';
+import { MetricType } from '../metrics.constants';
+
 import type { MaybeMetricMeta, Metric } from '../metrics.types';
 
 describe('EBNF adapter', () => {
@@ -42,7 +44,7 @@ describe('EBNF adapter', () => {
     const metric: Metric = {
       name: 'myMetric',
       values: [{ value: 1 }],
-      type: 'counter',
+      type: MetricType.COUNTER,
     };
 
     const result = ebnf.format(metric);
@@ -81,13 +83,13 @@ describe('EBNF adapter', () => {
         name: 'myMetric1',
         values: [{ value: 3.1415 }],
         help: 'short version of PI.',
-        type: 'gauge',
+        type: MetricType.GAUGE,
       },
       {
         name: 'myMetric2',
         values: [{ value: 1.41421 }],
         help: 'Square root of 2 probably.',
-        type: 'histogram',
+        type: MetricType.HISTOGRAM,
       },
       {
         name: 'myMetric3',
@@ -101,7 +103,7 @@ describe('EBNF adapter', () => {
           },
         ],
         help: "Approximation of Euler's number.",
-        type: 'untyped',
+        type: MetricType.UNTYPED,
       },
     ];
 

--- a/services/metrics-api/src/helpers/formats/ebnf.ts
+++ b/services/metrics-api/src/helpers/formats/ebnf.ts
@@ -1,0 +1,54 @@
+import { isMetricValueWithMeta } from '../metrics';
+import type { MaybeMetricMeta, Metric, MetricValue } from '../metrics.types';
+import type { MetricFormatter } from './formats.types';
+
+type CommentToken = 'HELP' | 'TYPE';
+type CommentTokenMetric = { [key in Lowercase<CommentToken>]?: string } & { name: string };
+
+function createTokenComment(prefix: CommentToken, metric: CommentTokenMetric): string | null {
+  const value: string | undefined = metric[prefix.toLowerCase() as keyof CommentTokenMetric];
+  return value ? `# ${prefix} ${metric.name} ${value}` : null;
+}
+
+function metricValueToEbnf(name: string, metricValue: MetricValue<MaybeMetricMeta>): string {
+  let str = `${name}`;
+
+  if (isMetricValueWithMeta(metricValue)) {
+    const labels = Object.entries(metricValue.meta ?? {}).map(
+      ([name, value]) => `${name}="${value}"`
+    );
+    if (labels && labels.length > 0) {
+      str += `{${labels.join(',')}}`;
+    }
+  }
+
+  str += ` ${metricValue.value}`;
+
+  return str;
+}
+
+function curriedMetricValueToEbnf(name: string): (metricValue: MetricValue) => string {
+  return (metricValue: MetricValue) => metricValueToEbnf(name, metricValue);
+}
+
+function metricToEbnf(metric: Metric): string {
+  const lines = [
+    createTokenComment('HELP', metric),
+    createTokenComment('TYPE', metric),
+    ...metric.values.map(curriedMetricValueToEbnf(metric.name)),
+  ].filter(Boolean);
+
+  return lines.join('\n');
+}
+
+function metricsToEbnf(metrics: Metric<MaybeMetricMeta>[]): string {
+  const metricStrings = metrics.map(metricToEbnf);
+  return metricStrings.filter(str => !!str).join('\n\n');
+}
+
+const formatter: MetricFormatter = {
+  format: metricToEbnf,
+  formatMultiple: metricsToEbnf,
+};
+
+export default formatter;

--- a/services/metrics-api/src/helpers/formats/ebnf.ts
+++ b/services/metrics-api/src/helpers/formats/ebnf.ts
@@ -11,20 +11,18 @@ function createTokenComment(prefix: CommentToken, metric: CommentTokenMetric): s
 }
 
 function metricValueToEbnf(name: string, metricValue: MetricValue<MaybeMetricMeta>): string {
-  let str = `${name}`;
+  let outputLine = `${name}`;
 
   if (isMetricValueWithMeta(metricValue)) {
     const labels = Object.entries(metricValue.meta ?? {}).map(
       ([name, value]) => `${name}="${value}"`
     );
-    if (labels && labels.length > 0) {
-      str += `{${labels.join(',')}}`;
-    }
+    outputLine += `{${labels.join(',')}}`;
   }
 
-  str += ` ${metricValue.value}`;
+  outputLine += ` ${metricValue.value}`;
 
-  return str;
+  return outputLine;
 }
 
 function curriedMetricValueToEbnf(name: string): (metricValue: MetricValue) => string {

--- a/services/metrics-api/src/helpers/formats/formats.types.ts
+++ b/services/metrics-api/src/helpers/formats/formats.types.ts
@@ -1,0 +1,9 @@
+import type { Metric } from '../metrics.types';
+
+export type SingleMetricFormatterFunc = (metric: Metric) => string;
+export type MultipleMetricsFormatterFunc = (metrics: Metric[]) => string;
+
+export interface MetricFormatter {
+  format: SingleMetricFormatterFunc;
+  formatMultiple: MultipleMetricsFormatterFunc;
+}

--- a/services/metrics-api/src/helpers/formats/index.ts
+++ b/services/metrics-api/src/helpers/formats/index.ts
@@ -1,0 +1,1 @@
+export { default as ebnf } from './ebnf';

--- a/services/metrics-api/src/helpers/metricBuilder.test.ts
+++ b/services/metrics-api/src/helpers/metricBuilder.test.ts
@@ -1,4 +1,4 @@
-import { MetricBuilder } from './metricBuilder';
+import MetricBuilder from './metricBuilder';
 import type { Metric, MetricValue } from './metrics.types';
 
 const MOCK_METRIC: Metric = {

--- a/services/metrics-api/src/helpers/metricBuilder.test.ts
+++ b/services/metrics-api/src/helpers/metricBuilder.test.ts
@@ -1,0 +1,162 @@
+import { MetricBuilder } from './metricBuilder';
+import type { Metric, MetricValue } from './metrics.types';
+
+const MOCK_METRIC: Metric = {
+  name: 'myMetric',
+  values: [{ value: 123 }],
+};
+
+describe('MetricBuilder', () => {
+  it('produces a simple metric', () => {
+    const metric = new MetricBuilder('myMetric').addValue({ value: 123 }).getMetric();
+
+    expect(metric).toEqual(MOCK_METRIC);
+  });
+
+  it('sets help', () => {
+    const expected: Metric = {
+      ...MOCK_METRIC,
+      help: 'my help text',
+    };
+
+    const metric = new MetricBuilder('myMetric')
+      .setHelp('my help text')
+      .addValue({ value: 123 })
+      .getMetric();
+
+    expect(metric).toEqual(expected);
+  });
+
+  it('sets type', () => {
+    const expected: Metric = {
+      ...MOCK_METRIC,
+      type: 'summary',
+    };
+
+    const metric = new MetricBuilder('myMetric')
+      .setType('summary')
+      .addValue({ value: 123 })
+      .getMetric();
+
+    expect(metric).toEqual(expected);
+  });
+
+  test.each([
+    [
+      'meta-less',
+      () => {
+        new MetricBuilder('myMetric').addValue({ value: 1 }).addValue({ value: 2 }).getMetric();
+      },
+    ],
+    [
+      'empty meta',
+      () => {
+        new MetricBuilder<Record<string, never>>('myMetric')
+          .addValue({ value: 1, meta: {} })
+          .addValue({ value: 2, meta: {} })
+          .getMetric();
+      },
+    ],
+    [
+      'meta-less first',
+      () => {
+        new MetricBuilder<{ a: string }>('myMetric')
+          .addValue({ value: 1 } as MetricValue<{ a: string }>)
+          .addValue({ value: 2, meta: { a: 'a' } })
+          .getMetric();
+      },
+    ],
+    [
+      'meta-less second',
+      () => {
+        new MetricBuilder<{ a: string }>('myMetric')
+          .addValue({ value: 1, meta: { a: 'a' } })
+          .addValue({ value: 2 } as MetricValue<{ a: string }>)
+          .getMetric();
+      },
+    ],
+  ])('throws on multiple meta-less values (%s)', (_, func) => {
+    expect(func).toThrow();
+  });
+
+  it('produces complex metric', () => {
+    const expected: Metric<{ source: string; purpose: string }> = {
+      ...MOCK_METRIC,
+      help: 'my helpful metric description',
+      type: 'gauge',
+      values: [
+        {
+          value: 123,
+          meta: {
+            source: 'wikipedia',
+            purpose: 'math',
+          },
+        },
+        {
+          value: 3.1415,
+          meta: {
+            source: 'github',
+            purpose: 'physics',
+          },
+        },
+        {
+          value: 420.1337,
+          meta: {
+            source: 'forums',
+            purpose: 'funny',
+          },
+        },
+        {
+          value: 42,
+          meta: {
+            source: 'galaxy',
+            purpose: 'everything',
+          },
+        },
+      ],
+    };
+
+    const metric = new MetricBuilder<{ source: string; purpose: string }>('myMetric')
+      .setHelp('my helpful metric description')
+      .setType('gauge')
+      .addValue({
+        value: 123,
+        meta: {
+          source: 'wikipedia',
+          purpose: 'math',
+        },
+      })
+      .addValue({
+        value: 3.1415,
+        meta: {
+          source: 'github',
+          purpose: 'physics',
+        },
+      })
+      .addValue({
+        value: 420.1337,
+        meta: {
+          source: 'forums',
+          purpose: 'funny',
+        },
+      })
+      .addValue({
+        value: 42,
+        meta: {
+          source: 'galaxy',
+          purpose: 'everything',
+        },
+      })
+      .getMetric();
+
+    expect(metric).toEqual(expected);
+  });
+
+  it('throws on no values', () => {
+    function func() {
+      new MetricBuilder('myMetric').getMetric();
+    }
+
+    expect(func).toThrow();
+  });
+});

--- a/services/metrics-api/src/helpers/metricBuilder.test.ts
+++ b/services/metrics-api/src/helpers/metricBuilder.test.ts
@@ -1,4 +1,5 @@
 import MetricBuilder from './metricBuilder';
+import { MetricType } from './metrics.constants';
 import type { Metric, MetricValue } from './metrics.types';
 
 const MOCK_METRIC: Metric = {
@@ -30,11 +31,11 @@ describe('MetricBuilder', () => {
   it('sets type', () => {
     const expected: Metric = {
       ...MOCK_METRIC,
-      type: 'summary',
+      type: MetricType.SUMMARY,
     };
 
     const metric = new MetricBuilder('myMetric')
-      .setType('summary')
+      .setType(MetricType.SUMMARY)
       .addValue({ value: 123 })
       .getMetric();
 
@@ -83,7 +84,7 @@ describe('MetricBuilder', () => {
     const expected: Metric<{ source: string; purpose: string }> = {
       ...MOCK_METRIC,
       help: 'my helpful metric description',
-      type: 'gauge',
+      type: MetricType.GAUGE,
       values: [
         {
           value: 123,
@@ -118,7 +119,7 @@ describe('MetricBuilder', () => {
 
     const metric = new MetricBuilder<{ source: string; purpose: string }>('myMetric')
       .setHelp('my helpful metric description')
-      .setType('gauge')
+      .setType(MetricType.GAUGE)
       .addValue({
         value: 123,
         meta: {

--- a/services/metrics-api/src/helpers/metricBuilder.ts
+++ b/services/metrics-api/src/helpers/metricBuilder.ts
@@ -1,0 +1,49 @@
+import { isMetricValueWithMeta } from './metrics';
+import type { MaybeMetricMeta, Metric, MetricType, MetricValue } from './metrics.types';
+
+export class MetricBuilder<TMeta extends MaybeMetricMeta = void> {
+  #metric: Metric<TMeta>;
+
+  constructor(name: string) {
+    this.#metric = {
+      name,
+      values: [],
+    };
+  }
+
+  setHelp(help: string): MetricBuilder<TMeta> {
+    this.#metric.help = help;
+    return this;
+  }
+
+  setType(type: MetricType): MetricBuilder<TMeta> {
+    this.#metric.type = type;
+    return this;
+  }
+
+  addValue(value: MetricValue<TMeta>): MetricBuilder<TMeta> {
+    const isMetricMetaless = !isMetricValueWithMeta(value);
+    const hasValuesAlready = this.#metric.values.length > 0;
+    const hasMetalessValues = this.#metric.values.some(value => !isMetricValueWithMeta(value));
+
+    const reachedMetalessLimit = (isMetricMetaless && hasValuesAlready) || hasMetalessValues;
+
+    if (reachedMetalessLimit) {
+      throw new Error(
+        `Metaless metric cannot contain more than 1 value (metric ${this.#metric.name})`
+      );
+    }
+
+    this.#metric.values.push(value);
+
+    return this;
+  }
+
+  getMetric(): Metric<TMeta> {
+    if (this.#metric.values.length == 0) {
+      throw new Error(`No values specified for metric ${this.#metric.name}`);
+    }
+
+    return this.#metric;
+  }
+}

--- a/services/metrics-api/src/helpers/metricBuilder.ts
+++ b/services/metrics-api/src/helpers/metricBuilder.ts
@@ -1,5 +1,7 @@
 import { isMetricValueWithMeta } from './metrics';
-import type { MaybeMetricMeta, Metric, MetricType, MetricValue } from './metrics.types';
+
+import type { MetricType } from './metrics.constants';
+import type { MaybeMetricMeta, Metric, MetricValue } from './metrics.types';
 
 export default class MetricBuilder<TMeta extends MaybeMetricMeta = void> {
   #metric: Metric<TMeta>;

--- a/services/metrics-api/src/helpers/metricBuilder.ts
+++ b/services/metrics-api/src/helpers/metricBuilder.ts
@@ -1,7 +1,7 @@
 import { isMetricValueWithMeta } from './metrics';
 import type { MaybeMetricMeta, Metric, MetricType, MetricValue } from './metrics.types';
 
-export class MetricBuilder<TMeta extends MaybeMetricMeta = void> {
+export default class MetricBuilder<TMeta extends MaybeMetricMeta = void> {
   #metric: Metric<TMeta>;
 
   constructor(name: string) {

--- a/services/metrics-api/src/helpers/metrics.constants.ts
+++ b/services/metrics-api/src/helpers/metrics.constants.ts
@@ -1,0 +1,7 @@
+export enum MetricType {
+  COUNTER = 'counter',
+  GAUGE = 'gauge',
+  HISTOGRAM = 'histogram',
+  SUMMARY = 'summary',
+  UNTYPED = 'untyped',
+}

--- a/services/metrics-api/src/helpers/metrics.test.ts
+++ b/services/metrics-api/src/helpers/metrics.test.ts
@@ -1,0 +1,29 @@
+import { isMetricValueWithMeta } from './metrics';
+import type { MaybeMetricMeta, MetricValue } from './metrics.types';
+
+describe('metrics', () => {
+  describe('isMetricValueWithMeta', () => {
+    it('returns true for valid metric objects with meta', () => {
+      const result = isMetricValueWithMeta({ value: 1, meta: { hello: 'world' } });
+      expect(result).toBe(true);
+    });
+
+    it('returns false for valid metric objects without meta', () => {
+      const result = isMetricValueWithMeta({ value: 1 });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for valid metric objects with empty meta', () => {
+      const result = isMetricValueWithMeta({ value: 1, meta: {} });
+      expect(result).toBe(false);
+    });
+
+    test.each([{}, [], ['meta'], { meta: {} }] as unknown as MetricValue<MaybeMetricMeta>[])(
+      'returns false for invalid values (%s)',
+      value => {
+        const result = isMetricValueWithMeta(value);
+        expect(result).toBe(false);
+      }
+    );
+  });
+});

--- a/services/metrics-api/src/helpers/metrics.ts
+++ b/services/metrics-api/src/helpers/metrics.ts
@@ -3,9 +3,5 @@ import type { MetricValue, MaybeMetricMeta, MetricValueWithMeta } from './metric
 export function isMetricValueWithMeta(
   metricValue: MetricValue<MaybeMetricMeta>
 ): metricValue is MetricValueWithMeta {
-  return (
-    'meta' in metricValue &&
-    typeof metricValue.meta === 'object' &&
-    Object.keys(metricValue.meta).length > 0
-  );
+  return 'meta' in metricValue && Object.keys(metricValue.meta).length > 0;
 }

--- a/services/metrics-api/src/helpers/metrics.ts
+++ b/services/metrics-api/src/helpers/metrics.ts
@@ -1,0 +1,11 @@
+import type { MetricValue, MaybeMetricMeta, MetricValueWithMeta } from './metrics.types';
+
+export function isMetricValueWithMeta(
+  metricValue: MetricValue<MaybeMetricMeta>
+): metricValue is MetricValueWithMeta {
+  return (
+    'meta' in metricValue &&
+    typeof metricValue.meta === 'object' &&
+    Object.keys(metricValue.meta).length > 0
+  );
+}

--- a/services/metrics-api/src/helpers/metrics.types.ts
+++ b/services/metrics-api/src/helpers/metrics.types.ts
@@ -1,0 +1,23 @@
+export type MetricType = 'counter' | 'gauge' | 'histogram' | 'summary' | 'untyped';
+
+export type MetricMetaBase = Record<string, unknown>;
+export type MaybeMetricMeta = MetricMetaBase | void;
+
+type MetricValueNoMeta = {
+  value: number;
+};
+type MetricMeta<TMeta extends MaybeMetricMeta> = TMeta extends void
+  ? MetricValueNoMeta
+  : { meta: TMeta };
+
+export type MetricValue<TMeta extends MaybeMetricMeta = void> = MetricValueNoMeta &
+  MetricMeta<TMeta>;
+
+export type MetricValueWithMeta = MetricValue<MetricMetaBase>;
+
+export interface Metric<TMeta extends MaybeMetricMeta = void> {
+  name: string;
+  help?: string;
+  type?: MetricType;
+  values: MetricValue<TMeta>[];
+}

--- a/services/metrics-api/src/helpers/metrics.types.ts
+++ b/services/metrics-api/src/helpers/metrics.types.ts
@@ -1,4 +1,4 @@
-export type MetricType = 'counter' | 'gauge' | 'histogram' | 'summary' | 'untyped';
+import type { MetricType } from './metrics.constants';
 
 export type MetricMetaBase = Record<string, unknown>;
 export type MaybeMetricMeta = MetricMetaBase | void;


### PR DESCRIPTION
## Explain the changes you’ve made

Added boilerplate for working with metrics. Includes metric types, a MetricBuilder class, formatting interfaces, and a EBNF format implementation for working with Prometheus.

## Explain why these changes are made

Foundation for exposing metrics to Prometheus/Grafana.

## How to test

Concrete example:

1. Checkout this branch
2. Run and verify the tests
3. Check that the implementation/logic makes sense

Example usage:
```typescript
type CaseMeta = {
  status: string;
};

const metrics = [
  new MetricBuilder<CaseMeta>("ekb_cases_open_total")
    .setHelp("The total number of open (not closed) cases.")
    .setType("gauge")
    .addValue({ value: 35, meta: { status: "notStarted" } })
    .addValue({ value: 10, meta: { status: "ongoing" } })
    .addValue({ value: 5, meta: { status: "signPending" } })
    .getMetric(),

  new MetricBuilder<CaseMeta>("ekb_cases_closed_total")
    .setHelp("The total number of closed (approved/declined) cases.")
    .setType("gauge")
    .addValue({ value: 1200, meta: { status: "approved" } })
    .addValue({ value: 610, meta: { status: "partiallyApproved" } })
    .addValue({ value: 420, meta: { status: "declined" } })
    .getMetric(),

  new MetricBuilder("ekb_sqs_total")
    .setHelp("Total cases in SQS submission queue.")
    .setType("gauge")
    .addValue({ value: 0 })
    .getMetric(),

  new MetricBuilder("ekb_dlq_total")
    .setHelp("Total cases in submission Dead Letter Queue.")
    .setType("gauge")
    .addValue({ value: 18 })
    .getMetric(),
];
```
