### PR TITLE
feat(copyattachment): copy attachment to co applicant

### DIFF
--- a/libs/S3.d.ts
+++ b/libs/S3.d.ts
@@ -7,6 +7,7 @@ declare namespace _default {
   export { deleteFile };
   export { deleteFiles };
   export { storeFile };
+  export { copyFileWithinBucket };
 }
 export default _default;
 declare function getSignedUrl(bucketName: any, method: any, params: any): string;
@@ -15,3 +16,8 @@ declare function getFile(bucketName: any, key: any): Promise<any>;
 declare function deleteFile(bucketName: any, key: any): Promise<any>;
 declare function deleteFiles(bucketName: string, keys: { Key: string }[]): Promise<any>;
 declare function storeFile(bucketName: any, key: any, body: any): Promise<any>;
+declare function copyFileWithinBucket(
+  bucketName: string,
+  sourceKey: string,
+  targetKey: string
+): Promise<void>;

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -36,6 +36,16 @@ async function deleteFile(bucketName, key) {
     .promise();
 }
 
+async function storeFile(bucketName, key, body) {
+  return s3Client
+    .putObject({
+      Bucket: bucketName,
+      Key: key,
+      Body: body,
+    })
+    .promise();
+}
+
 async function deleteFiles(bucketName, keys) {
   return s3Client
     .deleteObjects({
@@ -47,12 +57,12 @@ async function deleteFiles(bucketName, keys) {
     .promise();
 }
 
-async function storeFile(bucketName, key, body) {
+async function copyFileWithinBucket(bucketName, sourceKey, targetKey) {
   return s3Client
-    .putObject({
+    .copyObject({
       Bucket: bucketName,
-      Key: key,
-      Body: body,
+      CopySource: `${bucketName}/${sourceKey}`,
+      Key: targetKey,
     })
     .promise();
 }
@@ -64,4 +74,5 @@ export default {
   deleteFile,
   deleteFiles,
   storeFile,
+  copyFileWithinBucket,
 };

--- a/services/viva/microservice/serverless.yml
+++ b/services/viva/microservice/serverless.yml
@@ -49,6 +49,7 @@ provider:
             - s3:GetObject
             - s3:PutObject
             - s3:DeleteObject
+            - s3:ListBucket
           Resource:
             - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
             - Fn::Join:
@@ -316,3 +317,13 @@ functions:
               status:
                 type: [{ 'prefix': 'active:submitted' }]
               state: ['VIVA_CASE_CREATED']
+
+  copyAttachment:
+    handler: src/lambdas/copyAttachment.main
+    environment:
+      BUCKET_NAME: !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
+    events:
+      - s3:
+          bucket: !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
+          event: s3:ObjectCreated:*
+          existing: true

--- a/services/viva/microservice/serverless.yml
+++ b/services/viva/microservice/serverless.yml
@@ -49,7 +49,6 @@ provider:
             - s3:GetObject
             - s3:PutObject
             - s3:DeleteObject
-            - s3:ListBucket
           Resource:
             - Fn::ImportValue: ${self:custom.resourcesStage}-AttachmentsBucketArn
             - Fn::Join:

--- a/services/viva/microservice/serverless.yml
+++ b/services/viva/microservice/serverless.yml
@@ -322,7 +322,15 @@ functions:
     environment:
       BUCKET_NAME: !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
     events:
-      - s3:
-          bucket: !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
-          event: s3:ObjectCreated:*
-          existing: true
+      - eventBridge:
+          pattern:
+            source:
+              - 'aws.s3'
+            detail-type:
+              - 'Object Created'
+            detail:
+              bucket:
+                name:
+                  - !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
+              reason:
+                - 'PutObject'

--- a/services/viva/microservice/src/lambdas/copyAttachment.ts
+++ b/services/viva/microservice/src/lambdas/copyAttachment.ts
@@ -1,0 +1,80 @@
+import * as dynamoDb from '../libs/dynamoDb';
+import config from '../libs/config';
+import log from '../libs/logs';
+import S3 from '../libs/S3';
+
+import { CasePersonRole } from '../types/caseItem';
+import type { CaseItem } from '../types/caseItem';
+
+interface GetCasesResponse {
+  Items: CaseItem[];
+}
+
+interface S3Object {
+  key: string;
+}
+
+interface S3 {
+  object: S3Object;
+}
+
+export interface Record {
+  s3: S3;
+}
+
+export interface Dependencies {
+  copyFile: (sourceKey: string, destinationKey: string) => Promise<void>;
+  getLatestUpdatedCase: (personalNumber: string) => Promise<CaseItem>;
+}
+
+export interface LambdaRequest {
+  Records: Record[];
+}
+
+function copyFile(sourceKey: string, targetKey: string): Promise<void> {
+  const BUCKET_NAME = process.env.BUCKET_NAME ?? '';
+
+  return S3.copyFileWithinBucket(BUCKET_NAME, sourceKey, targetKey);
+}
+
+async function getLatestUpdatedCase(personalNumber: string): Promise<CaseItem> {
+  const PK = `USER#${personalNumber}`;
+
+  const queryParams = {
+    TableName: config.cases.tableName,
+    KeyConditionExpression: 'PK = :pk',
+    ExpressionAttributeValues: {
+      ':pk': PK,
+    },
+    ProjectionExpression: 'persons, updatedAt',
+  };
+
+  const result = (await dynamoDb.call('query', queryParams)) as GetCasesResponse;
+  const latestCase = (result.Items ?? []).sort((a, b) => a.updatedAt - b.updatedAt);
+
+  return latestCase[0] ?? ({} as CaseItem);
+}
+
+export async function copyAttachment(input: LambdaRequest, dependencies: Dependencies) {
+  const [personalNumber, filename] = input.Records[0].s3.object.key.split('/');
+  const caseItem = await dependencies.getLatestUpdatedCase(personalNumber);
+
+  const coApplicant = caseItem.persons.find(({ role }) => role === CasePersonRole.CoApplicant);
+  if (!coApplicant) {
+    return false;
+  }
+
+  await dependencies.copyFile(
+    `${personalNumber}/${filename}`,
+    `${coApplicant.personalNumber}/${filename}`
+  );
+
+  return true;
+}
+
+export const main = log.wrap(event => {
+  return copyAttachment(event, {
+    copyFile,
+    getLatestUpdatedCase,
+  });
+});

--- a/services/viva/microservice/src/lambdas/copyAttachment.ts
+++ b/services/viva/microservice/src/lambdas/copyAttachment.ts
@@ -57,7 +57,9 @@ export async function copyAttachment(
   input: FunctionInput,
   dependencies: Dependencies
 ): FunctionResponse {
-  const [personalNumber, filename] = input.detail.object.key.split('/');
+  const [personalNumber, ...rest] = input.detail.object.key.split('/');
+  const filename = rest.join('/');
+
   const caseItem = await dependencies.getLatestUpdatedCase(personalNumber);
 
   const coApplicant = caseItem?.persons.find(

--- a/services/viva/microservice/src/lambdas/copyAttachment.ts
+++ b/services/viva/microservice/src/lambdas/copyAttachment.ts
@@ -59,7 +59,10 @@ export async function copyAttachment(input: LambdaRequest, dependencies: Depende
   const [personalNumber, filename] = input.Records[0].s3.object.key.split('/');
   const caseItem = await dependencies.getLatestUpdatedCase(personalNumber);
 
-  const coApplicant = caseItem.persons.find(({ role }) => role === CasePersonRole.CoApplicant);
+  const coApplicant = caseItem.persons.find(
+    applicant =>
+      applicant.role === CasePersonRole.CoApplicant && applicant.personalNumber !== personalNumber
+  );
   if (!coApplicant) {
     return false;
   }

--- a/services/viva/microservice/src/lambdas/copyAttachment.ts
+++ b/services/viva/microservice/src/lambdas/copyAttachment.ts
@@ -23,9 +23,11 @@ export interface Dependencies {
   getLatestUpdatedCase: (personalNumber: string) => Promise<CaseItem | undefined>;
 }
 
-export interface LambdaRequest {
+export interface FunctionInput {
   detail: EventDetail;
 }
+
+type FunctionResponse = Promise<boolean>;
 
 function copyFile(sourceKey: string, targetKey: string): Promise<void> {
   const { BUCKET_NAME = '' } = process.env;
@@ -51,7 +53,10 @@ async function getLatestUpdatedCase(personalNumber: string): Promise<CaseItem | 
   return latestCase;
 }
 
-export async function copyAttachment(input: LambdaRequest, dependencies: Dependencies) {
+export async function copyAttachment(
+  input: FunctionInput,
+  dependencies: Dependencies
+): FunctionResponse {
   const [personalNumber, filename] = input.detail.object.key.split('/');
   const caseItem = await dependencies.getLatestUpdatedCase(personalNumber);
 

--- a/services/viva/microservice/src/lambdas/copyAttachment.ts
+++ b/services/viva/microservice/src/lambdas/copyAttachment.ts
@@ -60,8 +60,7 @@ export async function copyAttachment(input: LambdaRequest, dependencies: Depende
   const caseItem = await dependencies.getLatestUpdatedCase(personalNumber);
 
   const coApplicant = caseItem.persons.find(
-    applicant =>
-      applicant.role === CasePersonRole.CoApplicant && applicant.personalNumber !== personalNumber
+    person => person.role === CasePersonRole.CoApplicant && person.personalNumber !== personalNumber
   );
   if (!coApplicant) {
     return false;

--- a/services/viva/microservice/src/lambdas/copyAttachment.ts
+++ b/services/viva/microservice/src/lambdas/copyAttachment.ts
@@ -13,6 +13,7 @@ interface GetCasesResponse {
 interface S3EventObject {
   key: string;
 }
+
 export interface EventDetail {
   object: S3EventObject;
 }

--- a/services/viva/microservice/src/lambdas/copyAttachment.ts
+++ b/services/viva/microservice/src/lambdas/copyAttachment.ts
@@ -27,7 +27,7 @@ export interface LambdaRequest {
 }
 
 function copyFile(sourceKey: string, targetKey: string): Promise<void> {
-  const BUCKET_NAME = process.env.BUCKET_NAME ?? '';
+  const { BUCKET_NAME = '' } = process.env;
 
   return S3.copyFileWithinBucket(BUCKET_NAME, sourceKey, targetKey);
 }
@@ -45,9 +45,9 @@ async function getLatestUpdatedCase(personalNumber: string): Promise<CaseItem | 
   };
 
   const result = (await dynamoDb.call('query', queryParams)) as GetCasesResponse;
-  const latestCase = (result.Items ?? []).sort((a, b) => a.updatedAt - b.updatedAt);
+  const [latestCase] = (result.Items ?? []).sort((a, b) => a.updatedAt - b.updatedAt);
 
-  return latestCase[0];
+  return latestCase;
 }
 
 export async function copyAttachment(input: LambdaRequest, dependencies: Dependencies) {

--- a/services/viva/microservice/test/lambdas/copyAttachment.test.ts
+++ b/services/viva/microservice/test/lambdas/copyAttachment.test.ts
@@ -1,12 +1,15 @@
 import { copyAttachment } from '../../src/lambdas/copyAttachment';
 
-import type { Record, Dependencies } from '../../src/lambdas/copyAttachment';
+import type { S3Record, Dependencies } from '../../src/lambdas/copyAttachment';
 import { CasePersonRole } from '../../../types/caseItem';
 import type { CasePerson, CaseItem } from '../../../types/caseItem';
 
-const applicantPersonalNumber = '195001012222';
-const coApplicantPersonalNumber = '198901013333';
-const fileName = '12345678910';
+const applicantPersonalNumber = 'applicantPersonalNumber';
+const secondApplicantPersonalNumber = 'secondApplicantPersonalNumber';
+const coApplicantPersonalNumber = 'coApplicantPersonalNumber';
+const secondCoApplicantPersonalNumber = 'secondCoApplicantPersonalNumber';
+const fileName = '1111111/22222/3333';
+const secondFileName = '4444/55555/6666';
 
 function createPerson(personalNumber: string, role: CasePersonRole): CasePerson {
   return {
@@ -17,7 +20,7 @@ function createPerson(personalNumber: string, role: CasePersonRole): CasePerson 
   };
 }
 
-function createS3Record(key: string): Record {
+function createS3Record(key: string): S3Record {
   return {
     s3: {
       object: {
@@ -43,6 +46,7 @@ function createDependencies(partialDependencies: Partial<Dependencies> = {}): De
 
 it('copies file to coapplicant bucket', async () => {
   const copyFileMock = jest.fn();
+
   const result = await copyAttachment(
     {
       Records: [createS3Record(`${applicantPersonalNumber}/${fileName}`)],
@@ -53,14 +57,108 @@ it('copies file to coapplicant bucket', async () => {
   );
 
   expect(result).toBe(true);
+  expect(copyFileMock).toHaveBeenCalledTimes(1);
   expect(copyFileMock).toHaveBeenCalledWith(
     `${applicantPersonalNumber}/${fileName}`,
     `${coApplicantPersonalNumber}/${fileName}`
   );
 });
 
+it('copies files to coapplicant bucket with multiple records', async () => {
+  const copyFileMock = jest.fn();
+
+  const result = await copyAttachment(
+    {
+      Records: [
+        createS3Record(`${applicantPersonalNumber}/${fileName}`),
+        createS3Record(`${applicantPersonalNumber}/${secondFileName}`),
+      ],
+    },
+    createDependencies({
+      copyFile: copyFileMock,
+    })
+  );
+
+  expect(result).toBe(true);
+  expect(copyFileMock).toHaveBeenCalledTimes(2);
+  expect(copyFileMock).toHaveBeenCalledWith(
+    `${applicantPersonalNumber}/${fileName}`,
+    `${coApplicantPersonalNumber}/${fileName}`
+  );
+  expect(copyFileMock).toHaveBeenCalledWith(
+    `${applicantPersonalNumber}/${secondFileName}`,
+    `${coApplicantPersonalNumber}/${secondFileName}`
+  );
+});
+
+it('does not copy duplicate files', async () => {
+  const copyFileMock = jest.fn();
+
+  const result = await copyAttachment(
+    {
+      Records: [
+        createS3Record(`${applicantPersonalNumber}/${fileName}`),
+        createS3Record(`${applicantPersonalNumber}/${fileName}`),
+      ],
+    },
+    createDependencies({
+      copyFile: copyFileMock,
+    })
+  );
+
+  expect(result).toBe(true);
+  expect(copyFileMock).toHaveBeenCalledTimes(1);
+  expect(copyFileMock).toHaveBeenCalledWith(
+    `${applicantPersonalNumber}/${fileName}`,
+    `${coApplicantPersonalNumber}/${fileName}`
+  );
+});
+
+it('handles multiple applicants', async () => {
+  const copyFileMock = jest.fn();
+  const getLatestUpdatedCaseMock = jest
+    .fn()
+    .mockResolvedValueOnce({
+      persons: [
+        createPerson(applicantPersonalNumber, CasePersonRole.Applicant),
+        createPerson(coApplicantPersonalNumber, CasePersonRole.CoApplicant),
+      ],
+    })
+    .mockResolvedValueOnce({
+      persons: [
+        createPerson(secondApplicantPersonalNumber, CasePersonRole.Applicant),
+        createPerson(secondCoApplicantPersonalNumber, CasePersonRole.CoApplicant),
+      ],
+    });
+
+  const result = await copyAttachment(
+    {
+      Records: [
+        createS3Record(`${applicantPersonalNumber}/${fileName}`),
+        createS3Record(`${secondApplicantPersonalNumber}/${secondFileName}`),
+      ],
+    },
+    createDependencies({
+      copyFile: copyFileMock,
+      getLatestUpdatedCase: getLatestUpdatedCaseMock,
+    })
+  );
+
+  expect(result).toBe(true);
+  expect(copyFileMock).toHaveBeenCalledTimes(2);
+  expect(copyFileMock).toHaveBeenCalledWith(
+    `${applicantPersonalNumber}/${fileName}`,
+    `${coApplicantPersonalNumber}/${fileName}`
+  );
+  expect(copyFileMock).toHaveBeenCalledWith(
+    `${secondApplicantPersonalNumber}/${secondFileName}`,
+    `${secondCoApplicantPersonalNumber}/${secondFileName}`
+  );
+});
+
 it('skips copying of file if coapplicant does not exist', async () => {
   const copyFileMock = jest.fn();
+
   const result = await copyAttachment(
     {
       Records: [createS3Record(`${applicantPersonalNumber}/${fileName}`)],
@@ -74,12 +172,13 @@ it('skips copying of file if coapplicant does not exist', async () => {
     })
   );
 
-  expect(result).toBe(false);
+  expect(result).toBe(true);
   expect(copyFileMock).not.toHaveBeenCalled();
 });
 
 it('skips copying of file if personal number is the same as s3 key and is coapplicant', async () => {
   const copyFileMock = jest.fn();
+
   const result = await copyAttachment(
     {
       Records: [createS3Record(`${coApplicantPersonalNumber}/${fileName}`)],
@@ -93,6 +192,6 @@ it('skips copying of file if personal number is the same as s3 key and is coappl
     })
   );
 
-  expect(result).toBe(false);
+  expect(result).toBe(true);
   expect(copyFileMock).not.toHaveBeenCalled();
 });

--- a/services/viva/microservice/test/lambdas/copyAttachment.test.ts
+++ b/services/viva/microservice/test/lambdas/copyAttachment.test.ts
@@ -77,3 +77,22 @@ it('skips copying of file if coapplicant does not exist', async () => {
   expect(result).toBe(false);
   expect(copyFileMock).not.toHaveBeenCalled();
 });
+
+it('skips copying of file if personal number is the same as s3 key and is coapplicant', async () => {
+  const copyFileMock = jest.fn();
+  const result = await copyAttachment(
+    {
+      Records: [createS3Record(`${coApplicantPersonalNumber}/${fileName}`)],
+    },
+    createDependencies({
+      copyFile: copyFileMock,
+      getLatestUpdatedCase: () =>
+        Promise.resolve({
+          persons: [createPerson(coApplicantPersonalNumber, CasePersonRole.CoApplicant)],
+        }) as Promise<CaseItem>,
+    })
+  );
+
+  expect(result).toBe(false);
+  expect(copyFileMock).not.toHaveBeenCalled();
+});

--- a/services/viva/microservice/test/lambdas/copyAttachment.test.ts
+++ b/services/viva/microservice/test/lambdas/copyAttachment.test.ts
@@ -1,0 +1,79 @@
+import { copyAttachment } from '../../src/lambdas/copyAttachment';
+
+import type { Record, Dependencies } from '../../src/lambdas/copyAttachment';
+import { CasePersonRole } from '../../../types/caseItem';
+import type { CasePerson, CaseItem } from '../../../types/caseItem';
+
+const applicantPersonalNumber = '195001012222';
+const coApplicantPersonalNumber = '198901013333';
+const fileName = '12345678910';
+
+function createPerson(personalNumber: string, role: CasePersonRole): CasePerson {
+  return {
+    role,
+    personalNumber,
+    firstName: `firstName-${role}`,
+    lastName: `lastName-${role}`,
+  };
+}
+
+function createS3Record(key: string): Record {
+  return {
+    s3: {
+      object: {
+        key,
+      },
+    },
+  };
+}
+
+function createDependencies(partialDependencies: Partial<Dependencies> = {}): Dependencies {
+  return {
+    copyFile: () => Promise.resolve(),
+    getLatestUpdatedCase: () =>
+      Promise.resolve({
+        persons: [
+          createPerson(applicantPersonalNumber, CasePersonRole.Applicant),
+          createPerson(coApplicantPersonalNumber, CasePersonRole.CoApplicant),
+        ],
+      }) as Promise<CaseItem>,
+    ...partialDependencies,
+  };
+}
+
+it('copies file to coapplicant bucket', async () => {
+  const copyFileMock = jest.fn();
+  const result = await copyAttachment(
+    {
+      Records: [createS3Record(`${applicantPersonalNumber}/${fileName}`)],
+    },
+    createDependencies({
+      copyFile: copyFileMock,
+    })
+  );
+
+  expect(result).toBe(true);
+  expect(copyFileMock).toHaveBeenCalledWith(
+    `${applicantPersonalNumber}/${fileName}`,
+    `${coApplicantPersonalNumber}/${fileName}`
+  );
+});
+
+it('skips copying of file if coapplicant does not exist', async () => {
+  const copyFileMock = jest.fn();
+  const result = await copyAttachment(
+    {
+      Records: [createS3Record(`${applicantPersonalNumber}/${fileName}`)],
+    },
+    createDependencies({
+      copyFile: copyFileMock,
+      getLatestUpdatedCase: () =>
+        Promise.resolve({
+          persons: [createPerson(applicantPersonalNumber, CasePersonRole.Applicant)],
+        }) as Promise<CaseItem>,
+    })
+  );
+
+  expect(result).toBe(false);
+  expect(copyFileMock).not.toHaveBeenCalled();
+});

--- a/services/viva/microservice/test/lambdas/copyAttachment.test.ts
+++ b/services/viva/microservice/test/lambdas/copyAttachment.test.ts
@@ -1,15 +1,12 @@
 import { copyAttachment } from '../../src/lambdas/copyAttachment';
 
-import type { S3Record, Dependencies } from '../../src/lambdas/copyAttachment';
+import type { EventDetail, Dependencies } from '../../src/lambdas/copyAttachment';
 import { CasePersonRole } from '../../../types/caseItem';
 import type { CasePerson, CaseItem } from '../../../types/caseItem';
 
-const applicantPersonalNumber = 'applicantPersonalNumber';
-const secondApplicantPersonalNumber = 'secondApplicantPersonalNumber';
-const coApplicantPersonalNumber = 'coApplicantPersonalNumber';
-const secondCoApplicantPersonalNumber = 'secondCoApplicantPersonalNumber';
-const fileName = '1111111/22222/3333';
-const secondFileName = '4444/55555/6666';
+const applicantPersonalNumber = '195001012222';
+const coApplicantPersonalNumber = '198901013333';
+const fileName = '12345678910.jpg';
 
 function createPerson(personalNumber: string, role: CasePersonRole): CasePerson {
   return {
@@ -20,12 +17,10 @@ function createPerson(personalNumber: string, role: CasePersonRole): CasePerson 
   };
 }
 
-function createS3Record(key: string): S3Record {
+function createEventDetail(key: string): EventDetail {
   return {
-    s3: {
-      object: {
-        key,
-      },
+    object: {
+      key,
     },
   };
 }
@@ -49,7 +44,7 @@ it('copies file to coapplicant bucket', async () => {
 
   const result = await copyAttachment(
     {
-      Records: [createS3Record(`${applicantPersonalNumber}/${fileName}`)],
+      detail: createEventDetail(`${applicantPersonalNumber}/${fileName}`),
     },
     createDependencies({
       copyFile: copyFileMock,
@@ -57,111 +52,17 @@ it('copies file to coapplicant bucket', async () => {
   );
 
   expect(result).toBe(true);
-  expect(copyFileMock).toHaveBeenCalledTimes(1);
   expect(copyFileMock).toHaveBeenCalledWith(
     `${applicantPersonalNumber}/${fileName}`,
     `${coApplicantPersonalNumber}/${fileName}`
-  );
-});
-
-it('copies files to coapplicant bucket with multiple records', async () => {
-  const copyFileMock = jest.fn();
-
-  const result = await copyAttachment(
-    {
-      Records: [
-        createS3Record(`${applicantPersonalNumber}/${fileName}`),
-        createS3Record(`${applicantPersonalNumber}/${secondFileName}`),
-      ],
-    },
-    createDependencies({
-      copyFile: copyFileMock,
-    })
-  );
-
-  expect(result).toBe(true);
-  expect(copyFileMock).toHaveBeenCalledTimes(2);
-  expect(copyFileMock).toHaveBeenCalledWith(
-    `${applicantPersonalNumber}/${fileName}`,
-    `${coApplicantPersonalNumber}/${fileName}`
-  );
-  expect(copyFileMock).toHaveBeenCalledWith(
-    `${applicantPersonalNumber}/${secondFileName}`,
-    `${coApplicantPersonalNumber}/${secondFileName}`
-  );
-});
-
-it('does not copy duplicate files', async () => {
-  const copyFileMock = jest.fn();
-
-  const result = await copyAttachment(
-    {
-      Records: [
-        createS3Record(`${applicantPersonalNumber}/${fileName}`),
-        createS3Record(`${applicantPersonalNumber}/${fileName}`),
-      ],
-    },
-    createDependencies({
-      copyFile: copyFileMock,
-    })
-  );
-
-  expect(result).toBe(true);
-  expect(copyFileMock).toHaveBeenCalledTimes(1);
-  expect(copyFileMock).toHaveBeenCalledWith(
-    `${applicantPersonalNumber}/${fileName}`,
-    `${coApplicantPersonalNumber}/${fileName}`
-  );
-});
-
-it('handles multiple applicants', async () => {
-  const copyFileMock = jest.fn();
-  const getLatestUpdatedCaseMock = jest
-    .fn()
-    .mockResolvedValueOnce({
-      persons: [
-        createPerson(applicantPersonalNumber, CasePersonRole.Applicant),
-        createPerson(coApplicantPersonalNumber, CasePersonRole.CoApplicant),
-      ],
-    })
-    .mockResolvedValueOnce({
-      persons: [
-        createPerson(secondApplicantPersonalNumber, CasePersonRole.Applicant),
-        createPerson(secondCoApplicantPersonalNumber, CasePersonRole.CoApplicant),
-      ],
-    });
-
-  const result = await copyAttachment(
-    {
-      Records: [
-        createS3Record(`${applicantPersonalNumber}/${fileName}`),
-        createS3Record(`${secondApplicantPersonalNumber}/${secondFileName}`),
-      ],
-    },
-    createDependencies({
-      copyFile: copyFileMock,
-      getLatestUpdatedCase: getLatestUpdatedCaseMock,
-    })
-  );
-
-  expect(result).toBe(true);
-  expect(copyFileMock).toHaveBeenCalledTimes(2);
-  expect(copyFileMock).toHaveBeenCalledWith(
-    `${applicantPersonalNumber}/${fileName}`,
-    `${coApplicantPersonalNumber}/${fileName}`
-  );
-  expect(copyFileMock).toHaveBeenCalledWith(
-    `${secondApplicantPersonalNumber}/${secondFileName}`,
-    `${secondCoApplicantPersonalNumber}/${secondFileName}`
   );
 });
 
 it('skips copying of file if coapplicant does not exist', async () => {
   const copyFileMock = jest.fn();
-
   const result = await copyAttachment(
     {
-      Records: [createS3Record(`${applicantPersonalNumber}/${fileName}`)],
+      detail: createEventDetail(`${applicantPersonalNumber}/${fileName}`),
     },
     createDependencies({
       copyFile: copyFileMock,
@@ -172,16 +73,15 @@ it('skips copying of file if coapplicant does not exist', async () => {
     })
   );
 
-  expect(result).toBe(true);
+  expect(result).toBe(false);
   expect(copyFileMock).not.toHaveBeenCalled();
 });
 
 it('skips copying of file if personal number is the same as s3 key and is coapplicant', async () => {
   const copyFileMock = jest.fn();
-
   const result = await copyAttachment(
     {
-      Records: [createS3Record(`${coApplicantPersonalNumber}/${fileName}`)],
+      detail: createEventDetail(`${coApplicantPersonalNumber}/${fileName}`),
     },
     createDependencies({
       copyFile: copyFileMock,
@@ -192,6 +92,6 @@ it('skips copying of file if personal number is the same as s3 key and is coappl
     })
   );
 
-  expect(result).toBe(true);
+  expect(result).toBe(false);
   expect(copyFileMock).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Explain the changes you’ve made
Added an S3 event trigger which triggers whenever an attachment has been uploaded to the attachments bucket. This triggers a lambda that copies the attachment to a co-applicant if exists.

## Explain why these changes are made
Whenever a co applicant opens a form for sining, the form tries to download the attachments that the applicant has uploaded before. These attachments exists in a path in the s3 bucket which starts with the applicants personal number, which means that the co applicant cannot fetch those. Therefore we need to copy the files that has been uploaded by the applicant to the co applicants personal number as key in the s3 bucket.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service viva/microservice`
3. Make sure you have a case with both applicant and co applicant in persons property
4. upload a file directly to S3 in AWS console under the applicants key
5. The file should then be copied over to the co applicant
