### PR TITLE
Feat/get attachment by presigned url

### DIFF
--- a/libs/S3.d.ts
+++ b/libs/S3.d.ts
@@ -9,7 +9,7 @@ declare namespace _default {
   export { storeFile };
 }
 export default _default;
-declare function getSignedUrl(bucketName: any, method: any, params: any): string | undefined;
+declare function getSignedUrl(bucketName: any, method: any, params: any): string;
 declare function getFiles(bucketName: any, prefix: any): Promise<any>;
 declare function getFile(bucketName: any, key: any): Promise<any>;
 declare function deleteFile(bucketName: any, key: any): Promise<any>;

--- a/services/users-api/test/getAttachment.test.ts
+++ b/services/users-api/test/getAttachment.test.ts
@@ -1,12 +1,9 @@
-import { ResourceNotFoundError } from '@helsingborg-stad/npm-api-error-handling';
-
 import { getAttachment } from '../src/lambdas/getAttachment';
-
-import * as response from '../src/libs/response';
 
 import type { LambdaRequest, Dependencies } from '../src/lambdas/getAttachment';
 
 const defaultPersonalNumber = '197001011234';
+const defaultFileUrl = 'https://example.com';
 const defaultFilename = 'file';
 
 function createInput(): LambdaRequest {
@@ -23,54 +20,23 @@ function createInput(): LambdaRequest {
 function createDependencies(partialDependencies: Partial<Dependencies> = {}): Dependencies {
   return {
     decodeToken: () => ({ personalNumber: defaultPersonalNumber }),
-    getFile: () => Promise.resolve({ Body: Buffer.alloc(1), ContentType: 'file' }),
+    getFileUrl: () => defaultFileUrl,
     ...partialDependencies,
   };
 }
 
-function createHttpSuccessResponse(buffer: Buffer) {
-  return {
-    statusCode: 200,
-    isBase64Encoded: true,
-    headers: {
-      'Content-Type': 'file',
-    },
-    body: buffer.toString('base64'),
-  };
-}
+it('succesfully fetches file url for user', async () => {
+  const getFileUrlMock = jest.fn().mockReturnValue(defaultFileUrl);
 
-function createHttpFilesNotFoundResponse() {
-  return response.failure(new ResourceNotFoundError('No file found for user'));
-}
+  const result = await getAttachment(
+    createInput(),
+    createDependencies({
+      getFileUrl: getFileUrlMock,
+    })
+  );
 
-it('succesfully fetches file for user', async () => {
-  const buffer = Buffer.alloc(1);
-  const getFileMock = jest.fn().mockResolvedValueOnce({
-    Body: buffer,
-    ContentType: 'file',
+  expect(getFileUrlMock).toHaveBeenCalledWith(`${defaultPersonalNumber}/${defaultFilename}`);
+  expect(result).toEqual({
+    fileUrl: defaultFileUrl,
   });
-
-  const result = await getAttachment(
-    createInput(),
-    createDependencies({
-      getFile: getFileMock,
-    })
-  );
-
-  expect(getFileMock).toHaveBeenCalledWith(`${defaultPersonalNumber}/${defaultFilename}`);
-  expect(result).toEqual(createHttpSuccessResponse(buffer));
-});
-
-it('returns failure if no file is found', async () => {
-  const getFileMock = jest.fn().mockResolvedValueOnce(null);
-
-  const result = await getAttachment(
-    createInput(),
-    createDependencies({
-      getFile: getFileMock,
-    })
-  );
-
-  expect(getFileMock).toHaveBeenCalledWith(`${defaultPersonalNumber}/${defaultFilename}`);
-  expect(result).toEqual(createHttpFilesNotFoundResponse());
 });


### PR DESCRIPTION
## Explain the changes you’ve made
Make the getAttachment lambda return a presigned url instead of a buffer of the file

## Explain why these changes are made
A lambda function should not return the file content back to api gateway. This because of lambda and api gateway response restrictions. Best practice is to return a presigned url that the client can use to download the file with instead.

## How to test

Concrete example:

1. Checkout this branch
2. run `sls deploy` within service folder for `service users-api`
3. Debug the lambda locally and check the response
4. ... or runt it in the application
