### PR TITLE
feat(lambdawrapper): decode authorization token if exists

### DIFF
--- a/libs/lambdaWrappers.helpers.ts
+++ b/libs/lambdaWrappers.helpers.ts
@@ -3,11 +3,17 @@ import type { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { success, successRaw, failure } from './response';
 import type { LambdaError } from './errorTransformerFactory';
 
+import { decodeToken } from '../libs/token';
+
 export const inputTransformers = {
   fromApiGatewayEvent<TOutputType>(event: APIGatewayEvent): TOutputType {
+    const decodedToken = decodeToken(event);
     return {
       ...JSON.parse(event.body ?? '{}'),
       ...event.queryStringParameters,
+      ...(decodedToken && {
+        personalNumber: decodedToken.personalNumber,
+      }),
     } as unknown as TOutputType;
   },
 };

--- a/libs/token.js
+++ b/libs/token.js
@@ -5,9 +5,9 @@ import jwt from 'jsonwebtoken';
  * @param {*} httpEvent the event passed to the lambda
  */
 export function decodeToken(httpEvent) {
-  const authorizationValue = httpEvent.headers.Authorization;
+  const authorizationValue = httpEvent?.headers?.Authorization ?? '';
 
-  const token = authorizationValue.includes('Bearer')
+  const token = authorizationValue?.includes('Bearer')
     ? authorizationValue.substr(authorizationValue.indexOf(' ') + 1)
     : authorizationValue;
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/aws-lambda": "^8.10.97",
     "@types/deep-equal": "^1.0.1",
     "@types/jest": "^27.4.0",
+    "@types/jsonwebtoken": "^8.5.9",
     "@types/lodash.merge": "^4.6.7",
     "@types/node": "^14.14.27",
     "@types/semver-compare": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,6 +2461,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/jsonwebtoken@^8.5.9":
+  version "8.5.9"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz#2c064ecb0b3128d837d2764aa0b117b0ff6e4586"
+  integrity sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/lodash.clone@^4.5.7":
   version "4.5.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.clone/-/lodash.clone-4.5.7.tgz#110e28a71b3328c24d367162f48ae6aa9dab1973"


### PR DESCRIPTION
## Explain the changes you’ve made
The authorization token were missing in the input transformer and in the event to the lambda function, causing the decoding to fail in the function. Now we decode the token directly in the input transformer and put the result (personal number) directly in the input event to the lambda.

## Explain why these changes are made
Some lambda functions are dependent on a users personal number in order to request the right data. If the personal number isn't included in the function input, then the requests will fail.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service users-api` as an example
3. Run a lambda function that includes the wrapper for restJSON and check the input to the lambda
4. ... or run the lambdawrapper tests
