### PR TITLE
feat(getattachment): handle path parameters in input transformer

### DIFF
--- a/libs/lambdaWrappers.helpers.ts
+++ b/libs/lambdaWrappers.helpers.ts
@@ -11,6 +11,7 @@ export const inputTransformers = {
     return {
       ...JSON.parse(event.body ?? '{}'),
       ...event.queryStringParameters,
+      ...event.pathParameters,
       ...(decodedToken && {
         personalNumber: decodedToken.personalNumber,
       }),

--- a/services/users-api/src/lambdas/getAttachment.ts
+++ b/services/users-api/src/lambdas/getAttachment.ts
@@ -4,25 +4,17 @@ import S3 from '../libs/S3';
 
 const BUCKET_NAME = process.env.BUCKET_NAME;
 
-interface HttpHeaders {
-  Authorization: string;
-}
-
-interface PathParameters {
-  filename: string;
-}
-
-interface LambdaResponse {
+interface FunctionResponse {
   fileUrl: string | undefined;
 }
 
-export interface LambdaRequest {
-  headers: HttpHeaders;
-  pathParameters: PathParameters;
+export interface FunctionInput {
+  personalNumber: string;
+  filename: string;
 }
 
 export interface Dependencies {
-  decodeToken: (httpEvent: LambdaRequest) => { personalNumber: string };
+  decodeToken: (httpEvent: FunctionInput) => { personalNumber: string };
   getFileUrl: (key: string) => string | undefined;
 }
 
@@ -34,11 +26,10 @@ function getFileUrl(key: string): string | undefined {
 }
 
 export async function getAttachment(
-  input: LambdaRequest,
+  input: FunctionInput,
   dependencies: Dependencies
-): Promise<LambdaResponse> {
-  const { personalNumber } = dependencies.decodeToken(input);
-  const { filename } = input.pathParameters;
+): Promise<FunctionResponse> {
+  const { personalNumber, filename } = input;
 
   const key = `${personalNumber}/${filename}`;
 

--- a/services/users-api/test/getAttachment.test.ts
+++ b/services/users-api/test/getAttachment.test.ts
@@ -1,19 +1,15 @@
 import { getAttachment } from '../src/lambdas/getAttachment';
 
-import type { LambdaRequest, Dependencies } from '../src/lambdas/getAttachment';
+import type { FunctionInput, Dependencies } from '../src/lambdas/getAttachment';
 
 const defaultPersonalNumber = '197001011234';
 const defaultFileUrl = 'https://example.com';
 const defaultFilename = 'file';
 
-function createInput(): LambdaRequest {
+function createInput(): FunctionInput {
   return {
-    headers: {
-      Authorization: defaultPersonalNumber,
-    },
-    pathParameters: {
-      filename: defaultFilename,
-    },
+    personalNumber: defaultPersonalNumber,
+    filename: defaultFilename,
   };
 }
 


### PR DESCRIPTION
## Explain the changes you’ve made
PathParameters were not included in the function input, making the lambda miss some important properties in its execution. PathParameters are therefore added in the restJSON lambda wrapper.

## Explain why these changes are made
The lambda function expected pathParameters and filename to be included as input to the function, when added the lambda wrapper the pathparameters property were removed.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service user-api`
3. Run the lambda function `getAttachment` and check if its running OK.
