### PR TITLE
fix(attachment.ts): use correct property for viva attachment name

### DIFF
--- a/services/viva/helpers/attachment.ts
+++ b/services/viva/helpers/attachment.ts
@@ -70,7 +70,7 @@ async function createAttachmentFromAnswers(
 
       const VivaAttachment: VivaAttachment = {
         id: s3AttachmentFileKey,
-        name: attachment.uploadedId,
+        name: attachment.externalDisplayName,
         category: vivaAttachmentCategory,
         fileBase64: file.Body.toString('base64'),
       };

--- a/services/viva/microservice/test/helpers/attachment.test.ts
+++ b/services/viva/microservice/test/helpers/attachment.test.ts
@@ -71,19 +71,19 @@ it('return a list of attachment objects', async () => {
   expect(result).toEqual([
     {
       id: '199492921234/1234',
-      name: '1234',
+      name: 'externalDisplayName_0.png',
       category: '',
       fileBase64: 'Some body here0',
     },
     {
       id: '199492921234/4321',
-      name: '4321',
+      name: 'externalDisplayName_1.png',
       category: '',
       fileBase64: 'Some body here1',
     },
     {
       id: '199492921234/7890',
-      name: '7890',
+      name: 'externalDisplayNameA_0.png',
       category: 'expenses',
       fileBase64: 'Some body hereA0',
     },
@@ -183,13 +183,13 @@ it('return list of attachment where category is set to expenses', async () => {
   expect(result).toEqual([
     {
       id: '199492921234/3344',
-      name: '3344',
+      name: 'externalDisplayName_0.jpg',
       category: 'expenses',
       fileBase64: 'Some body here0',
     },
     {
       id: '199492921234/6611',
-      name: '6611',
+      name: 'externalDisplayName_1.jpg',
       category: 'expenses',
       fileBase64: 'Some body here1',
     },


### PR DESCRIPTION
## Explain the changes you’ve made
The api were sending the wrong name for attachments to VIVA, making VIVA display the uploaded id instead of the external display name.

## Explain why these changes are made
The id of an attachment should not be (and is not a good name) displayed to administrators in VIVA. The uploaded id is only for EKB API.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for `service viva microservice`
3. Sen in an application to VIVA with attachments
