### PR TITLE
Feat/eventbridge dlq

### DIFF
--- a/services/case-ms/serverless.yml
+++ b/services/case-ms/serverless.yml
@@ -65,3 +65,7 @@ functions:
               - pdfMs.generate
             detail-type:
               - PdfMsGenerateSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn

--- a/services/html-pdf-ms/serverless.yml
+++ b/services/html-pdf-ms/serverless.yml
@@ -66,3 +66,7 @@ functions:
               - vivaMs.generateRecurringCaseHtml
             detail-type:
               - htmlGeneratedSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn

--- a/services/navet-ms/serverless.yml
+++ b/services/navet-ms/serverless.yml
@@ -57,3 +57,7 @@ functions:
           pattern:
             source:
               - bankId.collect
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn

--- a/services/users-ms/serverless.yml
+++ b/services/users-ms/serverless.yml
@@ -56,18 +56,30 @@ functions:
               - navetMs.pollUser
             detail-type:
               - navetMsPollUserSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
       - eventBridge:
           pattern:
             source:
               - usersMs.createUser
             detail-type:
               - usersMsCreateUserSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
       - eventBridge:
           pattern:
             source:
               - casesApi.getCaseList
             detail-type:
               - casesApiInvokeSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   create:
     handler: src/lambdas/createUser.main
@@ -78,3 +90,7 @@ functions:
               - usersMs.findUser
             detail-type:
               - usersMsFindUserUnsucceeded
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn

--- a/services/viva/microservice/serverless.yml
+++ b/services/viva/microservice/serverless.yml
@@ -101,12 +101,20 @@ functions:
               - usersMs.findUser
             detail-type:
               - usersMsFindUserSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
       - eventBridge:
           pattern:
             source:
               - vivaMs.submitApplication
             detail-type:
               - applicationReceivedSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   personApplicationStatus:
     handler: src/lambdas/personApplicationStatus.main
@@ -118,6 +126,10 @@ functions:
               - vivaMs.applicationStatus
             detail-type:
               - applicationStatusSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   personApplication:
     handler: src/lambdas/personApplication.main
@@ -129,6 +141,10 @@ functions:
               - vivaMs.personApplicationStatus
             detail-type:
               - checkOpenPeriodSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   createNewVivaCase:
     handler: src/lambdas/createNewVivaCase.main
@@ -141,6 +157,10 @@ functions:
               - vivaMs.personApplicationStatus
             detail-type:
               - checkOpenNewApplicationSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   createVivaCase:
     handler: src/lambdas/createVivaCase.main
@@ -153,6 +173,10 @@ functions:
               - vivaMs.personApplication
             detail-type:
               - personDetailSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   submitApplication:
     handler: src/lambdas/submitApplication.main
@@ -174,6 +198,10 @@ functions:
               - vivaMs.applicationStatus
             detail-type:
               - applicationStatusSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   checkCompletionsStatus:
     handler: src/lambdas/checkCompletionsStatus.main
@@ -185,6 +213,10 @@ functions:
               - vivaMs.syncCaseCompletions
             detail-type:
               - syncSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   setCaseCompletions:
     handler: src/lambdas/setCaseCompletions.main
@@ -203,6 +235,10 @@ functions:
                   { 'anything-but': 'VIVA_RANDOM_CHECK_RECEIVED' },
                   { 'anything-but': 'VIVA_COMPLETION_RECEIVED' },
                 ]
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   checkCompletionsDueDate:
     handler: src/lambdas/checkCompletionsDueDate.main
@@ -217,6 +253,10 @@ functions:
             detail:
               caseStatusType: [{ 'anything-but': { 'prefix': 'active:processing' } }]
               caseState: [{ 'anything-but': 'VIVA_APPLICATION_RECEIVED' }]
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   submitCompletion:
     handler: src/lambdas/submitCompletion.main
@@ -234,6 +274,10 @@ functions:
               status:
                 type: [{ 'prefix': 'active:submitted' }]
               state: ['VIVA_RANDOM_CHECK_REQUIRED', 'VIVA_COMPLETION_REQUIRED']
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   syncOfficers:
     handler: src/lambdas/syncOfficers.main
@@ -251,6 +295,10 @@ functions:
                 NewImage:
                   provider:
                     S: ['VIVA']
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   syncWorkflow:
     handler: src/lambdas/syncWorkflow.main
@@ -262,6 +310,10 @@ functions:
               - bankId.collect
             detail-type:
               - BankIdCollectComplete
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   decideCaseStatus:
     handler: src/lambdas/decideCaseStatus.main
@@ -272,6 +324,10 @@ functions:
               - vivaMs.syncWorkflow
             detail-type:
               - syncWorkflowSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   syncExpiryTime:
     handler: src/lambdas/syncExpiryTime.main
@@ -280,14 +336,26 @@ functions:
           pattern:
             source:
               - casesApi.updateCase
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
       - eventBridge:
           pattern:
             source:
               - vivaMs.decideCaseStatus
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
       - eventBridge:
           pattern:
             source:
               - vivaMs.setCaseCompletions
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   syncNewCaseWorkflowId:
     handler: src/lambdas/syncNewCaseWorkflowId.main
@@ -299,6 +367,10 @@ functions:
               - vivaMs.applicationStatus
             detail-type:
               - applicationStatusSuccess
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   generateRecurringCaseHtml:
     handler: src/lambdas/generateRecurringCaseHtml.main
@@ -315,6 +387,10 @@ functions:
               status:
                 type: [{ 'prefix': 'active:submitted' }]
               state: ['VIVA_CASE_CREATED']
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn
 
   copyAttachment:
     handler: src/lambdas/copyAttachment.main
@@ -333,3 +409,7 @@ functions:
                   - !ImportValue ${self:custom.resourcesStage}-AttachmentsBucketName
               reason:
                 - 'PutObject'
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn: !ImportValue ${self:custom.resourcesStage}-EventBridgeDeadLetterQueueArn


### PR DESCRIPTION
## Explain the changes you’ve made
Added SQS dead letter queue for EventBridge rules that fails to be delivered to its destination, example lambda

## Explain why these changes are made
When an eventbridge message fails to be delivered, messages are retried some times and then removed by eventbridge. In order to easier troubleshoot when this happens, messages are delivered to the dead letter queue and kept for 4 days.

Messages in the dead letter queue also provides the reasen for not being delivered, authorization failure as an example

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for all services
3. Change the resource-based policy on any lambda that uses eventbridge and forbid eventbridge to invoke it.
4. Trigger the event and check if the message appears in the DLQ.

**NOTE **
This PR is dependent on https://github.com/helsingborg-stad/helsingborg-io-sls-resources/pull/116
