### PR TITLE
feat(serverless.yml): update lambda node runtime from 14 to 16

### DIFF
--- a/services/auth/token/serverless.yml
+++ b/services/auth/token/serverless.yml
@@ -14,7 +14,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/bankid-api/serverless.yml
+++ b/services/bankid-api/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/case-ms/serverless.yml
+++ b/services/case-ms/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/cases-api/serverless.yml
+++ b/services/cases-api/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/forms-api/serverless.yml
+++ b/services/forms-api/serverless.yml
@@ -14,7 +14,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/html-pdf-ms/serverless.yml
+++ b/services/html-pdf-ms/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/metrics-api/serverless.yml
+++ b/services/metrics-api/serverless.yml
@@ -14,7 +14,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/navet-ms/serverless.yml
+++ b/services/navet-ms/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/status-api/serverless.yml
+++ b/services/status-api/serverless.yml
@@ -14,7 +14,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/stream-eventbridge-ms/serverless.yml
+++ b/services/stream-eventbridge-ms/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/users-api/serverless.yml
+++ b/services/users-api/serverless.yml
@@ -14,7 +14,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/users-ms/serverless.yml
+++ b/services/users-ms/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/version-api/serverless.yml
+++ b/services/version-api/serverless.yml
@@ -14,7 +14,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/viva/api/cases/serverless.yml
+++ b/services/viva/api/cases/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional

--- a/services/viva/microservice/serverless.yml
+++ b/services/viva/microservice/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: eu-north-1
   endpointType: regional


### PR DESCRIPTION
## Explain the changes you’ve made
Update lambda node runtime from version 14 to 16

## Explain why these changes are made
To have an updated lambda runtime gives multiple advantages like improved stability and performance.

## How to test

1. Checkout this branch
2. run `sls deploy` within service folder for all services
3. Run application -> OK
4. Run tests -> OK

**NOTE:**
Serverless framework with version 2 will warn about the updated runtime since it's not supported in their validation. Node 16 is supported from version 3 but serverless will not forbid you to deploy a lambda with another runtime if its still supported by lambda.

Here is the list of supported lambda runtimes:
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

**Updated lambda runtime settings:**
<img width="446" alt="image" src="https://user-images.githubusercontent.com/9610681/207254084-9da25e3e-5571-4fe4-899a-2025fac38371.png">

