### PR TITLE
Fix/allow new application change

### DIFF
--- a/services/viva/helpers/newApplication.ts
+++ b/services/viva/helpers/newApplication.ts
@@ -1,0 +1,10 @@
+import type { VivaParametersResponse } from '../types/ssmParameters';
+
+export function isFormNewApplication(
+  formIds: VivaParametersResponse,
+  targetFormIdValue: string
+): boolean {
+  return Object.entries(formIds).some(
+    ([key, value]) => key.startsWith('new') && value === targetFormIdValue
+  );
+}

--- a/services/viva/microservice/serverless.yml
+++ b/services/viva/microservice/serverless.yml
@@ -73,6 +73,12 @@ provider:
         - Effect: Allow
           Action:
             - dynamodb:Query
+          Resource:
+            - !ImportValue ${self:custom.resourcesStage}-CasesTableAllIndexArn
+
+        - Effect: Allow
+          Action:
+            - dynamodb:Query
             - dynamodb:GetItem
           Resource:
             - 'Fn::ImportValue': ${self:custom.resourcesStage}-UsersTableArn

--- a/services/viva/microservice/src/lambdas/generateRecurringCaseHtml.ts
+++ b/services/viva/microservice/src/lambdas/generateRecurringCaseHtml.ts
@@ -13,6 +13,7 @@ import S3 from '../libs/S3';
 import createRecurringCaseTemplate from '../helpers/createRecurringCaseTemplate';
 import createCaseTemplate from '../helpers/createCaseTemplate';
 import putVivaMsEvent from '../helpers/putVivaMsEvent';
+import { isFormNewApplication } from '../helpers/newApplication';
 import handlebars from '../helpers/htmlTemplate';
 import { cases } from '../helpers/query';
 
@@ -139,13 +140,6 @@ function getClosedCases(partitionKey: string) {
 async function getFormIds(): Promise<VivaParametersResponse> {
   const formIds = await params.read(config.cases.providers.viva.envsKeyName);
   return formIds;
-}
-
-function isFormNewApplication(formIds: VivaParametersResponse, targetFormId: string): boolean {
-  return Object.entries(formIds)
-    .filter(([key]) => key.startsWith('new'))
-    .map(([, value]) => value)
-    .includes(targetFormId);
 }
 
 export async function generateRecurringCaseHtml(

--- a/services/viva/microservice/test/helpers/newApplication.test.ts
+++ b/services/viva/microservice/test/helpers/newApplication.test.ts
@@ -1,0 +1,51 @@
+import { isFormNewApplication } from '../../src/helpers/newApplication';
+
+const MOCK_FORMIDS = {
+  recurringFormId: '1',
+  randomCheckFormId: '2',
+  completionFormId: '3',
+  newApplicationFormId: '4',
+  newApplicationRandomCheckFormId: '5',
+  newApplicationCompletionFormId: '6',
+};
+
+describe('newApplication', () => {
+  describe('isFormNewApplication', () => {
+    test.each([
+      {
+        formIdKey: 'randomCheckFormId',
+        targetId: MOCK_FORMIDS.recurringFormId,
+        expected: false,
+      },
+      {
+        formIdKey: 'recurringFormId',
+        targetId: MOCK_FORMIDS.randomCheckFormId,
+        expected: false,
+      },
+      {
+        formIdKey: 'completionFormId',
+        targetId: MOCK_FORMIDS.completionFormId,
+        expected: false,
+      },
+      {
+        formIdKey: 'newApplicationFormId',
+        targetId: MOCK_FORMIDS.newApplicationFormId,
+        expected: true,
+      },
+      {
+        formIdKey: 'newApplicationRandomCheckFormId',
+        targetId: MOCK_FORMIDS.newApplicationRandomCheckFormId,
+        expected: true,
+      },
+      {
+        formIdKey: 'newApplicationCompletionFormId',
+        targetId: MOCK_FORMIDS.newApplicationCompletionFormId,
+        expected: true,
+      },
+    ])('$formIdKey - $expected', ({ targetId, expected }) => {
+      const result = isFormNewApplication(MOCK_FORMIDS, targetId);
+
+      expect(result).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
## Explain the changes you’ve made
Refactored `createNewVivaCase` lambda to not create new viva cases when its not supposed to. Implemented logic which follows the decide chart:

![image](https://user-images.githubusercontent.com/9610681/207586744-0fd4f340-b3aa-4896-9430-131e7b1939e7.png)

## Explain why these changes are made
The grundansökan-button did appear when not supposed to, which meant that a new application case where created. This PR hopefully fixes the issue and avoid creating new application cases when not needed.

## How to test

Concrete example:

1. Checkout this branch
2. run `sls deploy` within service folder for `service viva`
3. Run the EKB application and add a co-applicant before answering the grundansökan form
4. Login as the co-applicant
5. The grundansökan button should not be visible
6. no new cases should either be created in cases table
