### PR TITLE
fix(html-pdf-ms): downgrade nodejs to 14

### DIFF
--- a/services/html-pdf-ms/serverless.yml
+++ b/services/html-pdf-ms/serverless.yml
@@ -13,7 +13,7 @@ package:
 provider:
   lambdaHashingVersion: 20201221
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs14.x
   stage: dev
   region: eu-north-1
   endpointType: regional


### PR DESCRIPTION
temp fix for chrome-aws-lambda issues

## Explain the changes you’ve made

Downgraded nodejs from 16 to 14 for html-pdf-ms.

## Explain why these changes are made

chrome-aws-lambda (the layer in resources) is incompatible with nodejs >14. A separate story has been created in the backlog to address this properly.

## How to test

Concrete example:

1. Checkout this branch
2. Deploy
3. Verify PDFs are created as expected
