### PR TITLE
refactor(openapi): add docs for status messages

### DIFF
--- a/services/status-api/openapi.yml
+++ b/services/status-api/openapi.yml
@@ -21,14 +21,15 @@ paths:
         - Status
       summary: Get API status messages.
       description: |
-        This endpoint returns a list of messages that would be used and displayed by a consumer.
-        The list of messages returned in the response could be on of the following:
+        This endpoint returns a filtered list of message objects and includes only messages that are currently valid
+        based on their start and expiry dates.
 
-        1. info
-        2. warning
-        3. maintenance
+         The list of messages returned in the response could be in one of the following 
+         types (starting with the lowest severity first):
 
-        in which the severity of the message is increased with start from position1.
+         1. info
+         2. warning
+         3. maintenance
 
       security:
         - ApiKeyAuth: []

--- a/services/status-api/openapi.yml
+++ b/services/status-api/openapi.yml
@@ -39,12 +39,6 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/GetStatusResponse'
-        '401':
-          description: Invalid JWT.
-          content:
-            'application/json':
-              schema:
-                $ref: '../common-openapi.yml#/components/schemas/jsonApiError'
         '403':
           $ref: '../common-openapi.yml#/components/responses/missingApiKeyResponse'
 

--- a/services/status-api/openapi.yml
+++ b/services/status-api/openapi.yml
@@ -32,6 +32,13 @@ paths:
 
       security:
         - ApiKeyAuth: []
+      parameters:
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+            format: JWT
+          required: true
       responses:
         '200':
           description: OK.

--- a/services/status-api/openapi.yml
+++ b/services/status-api/openapi.yml
@@ -32,13 +32,6 @@ paths:
 
       security:
         - ApiKeyAuth: []
-      parameters:
-        - in: header
-          name: Authorization
-          schema:
-            type: string
-            format: JWT
-          required: true
       responses:
         '200':
           description: OK.

--- a/services/status-api/openapi.yml
+++ b/services/status-api/openapi.yml
@@ -1,0 +1,96 @@
+openapi: '3.0.3'
+info:
+  title: Status
+  description: Api for fetching api status messages.
+  contact:
+    name: GitHub Repo
+    url: https://github.com/helsingborg-stad/helsingborg-io-sls-api
+  version: '1.0'
+  license:
+    name: MIT
+    url: 'https://github.com/helsingborg-stad/helsingborg-io-sls-api#license'
+servers:
+  - url: https://dev.api.helsingborg.io
+  - url: https://release.api.helsingborg.io
+  - url: https://api.helsingborg.io
+
+paths:
+  /status/messages:
+    get:
+      tags:
+        - Status
+      summary: Get API status messages.
+      description: |
+        This endpoint returns a list of messages that would be used and displayed by a consumer.
+        The list of messages returned in the response could be on of the following:
+
+        1. info
+        2. warning
+        3. maintenance
+
+        in which the severity of the message is increased with start from position1.
+
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: OK.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/GetStatusResponse'
+        '401':
+          description: Invalid JWT.
+          content:
+            'application/json':
+              schema:
+                $ref: '../common-openapi.yml#/components/schemas/jsonApiError'
+        '403':
+          $ref: '../common-openapi.yml#/components/responses/missingApiKeyResponse'
+
+components:
+  securitySchemes:
+    $ref: '../common-openapi.yml#/components/securitySchemes'
+
+  schemas:
+    Message:
+      type: object
+      properties:
+        title:
+          type: string
+        text:
+          type: string
+
+    MessageItem:
+      type: object
+      properties:
+        message:
+          type: object
+          $ref: '#/components/schemas/Message'
+        type:
+          type: string
+          enum: [info, warning, maintenance]
+        start:
+          type: string
+        expiry:
+          type: string
+
+    GetStatusResponse:
+      type: object
+      properties:
+        jsonapi:
+          type: object
+          properties:
+            version:
+              type: string
+              example: '1.0'
+            data:
+              type: object
+              properties:
+                attributes:
+                  type: object
+                  properties:
+                    messages:
+                      type: array
+                      items:
+                        $ref: '#/components/schemas/MessageItem'


### PR DESCRIPTION
## Explain the changes you’ve made
Added openapi documentation for status api

## Explain why these changes are made
We want our api:s to be documented, hence creating this openapi docs.

## How to test

1. Checkout this branch
2. Open status-api with VsCode
3. runt the openapi.yml file in swagger
