### PR TITLE
Refactor/ekb collector metrics

### DIFF
--- a/services/metrics-api/serverless.yml
+++ b/services/metrics-api/serverless.yml
@@ -54,5 +54,4 @@ functions:
       - http:
           path: metrics/ekb
           method: get
-          private: true
           cors: true

--- a/services/metrics-api/serverless.yml
+++ b/services/metrics-api/serverless.yml
@@ -21,6 +21,7 @@ provider:
   versionFunctions: false
   tracing:
     lambda: true
+
   apiGateway:
     restApiId: !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiId
     restApiRootResourceId: !ImportValue ${self:custom.stage}-ExtApiGatewayRestApiRootResourceId

--- a/services/metrics-api/src/helpers/cases.ts
+++ b/services/metrics-api/src/helpers/cases.ts
@@ -25,6 +25,12 @@ export function createStatusCollection(cases: CaseItem[]): StatusCollection {
   return cases.reduce(casesReducer, initial);
 }
 
+export function removeEmptyMetricsValues(collection: StatusCollection): StatusCollection {
+  return Object.fromEntries(
+    Object.entries(collection).filter(([, value]) => Object.values(value).some(v => v > 0))
+  ) as StatusCollection;
+}
+
 function get(): Promise<CaseItem[]> {
   const params: CasesQueryParams = {
     key: 'GSI2PK',

--- a/services/metrics-api/src/helpers/cases.ts
+++ b/services/metrics-api/src/helpers/cases.ts
@@ -5,7 +5,7 @@ import type { CasesQueryParams, CaseItem } from './query/cases/types';
 
 export type StatusCollection = Record<MetricsKey, Record<string, number>>;
 
-function casesReducer(
+function casesToStatusCollectionReducer(
   accumulated: StatusCollection,
   { status: { type: statusType } }: CaseItem
 ): StatusCollection {
@@ -22,7 +22,7 @@ export function createStatusCollection(cases: CaseItem[]): StatusCollection {
     [MetricsKey.EKB_CASES_OPEN_TOTAL]: {},
     [MetricsKey.EKB_CASES_CLOSED_TOTAL]: {},
   };
-  return cases.reduce(casesReducer, initial);
+  return cases.reduce(casesToStatusCollectionReducer, initial);
 }
 
 export function removeEmptyMetricsValues(collection: StatusCollection): StatusCollection {

--- a/services/metrics-api/src/helpers/cases.ts
+++ b/services/metrics-api/src/helpers/cases.ts
@@ -1,8 +1,31 @@
 import { cases } from './query';
 import { getDatePattern } from './getDatePattern';
+import { MetricsKey } from './metrics.constants';
 import type { CasesQueryParams, CaseItem } from './query/cases/types';
 
-async function get(): Promise<CaseItem[]> {
+export type StatusCollection = Record<MetricsKey, Record<string, number>>;
+
+function casesReducer(
+  accumulated: StatusCollection,
+  { status: { type: statusType } }: CaseItem
+): StatusCollection {
+  const key = statusType.startsWith('closed:')
+    ? MetricsKey.EKB_CASES_CLOSED_TOTAL
+    : MetricsKey.EKB_CASES_OPEN_TOTAL;
+
+  accumulated[key][statusType] = (accumulated[key][statusType] ?? 0) + 1;
+  return accumulated;
+}
+
+export function createStatusCollection(cases: CaseItem[]): StatusCollection {
+  const initial: StatusCollection = {
+    [MetricsKey.EKB_CASES_OPEN_TOTAL]: {},
+    [MetricsKey.EKB_CASES_CLOSED_TOTAL]: {},
+  };
+  return cases.reduce(casesReducer, initial);
+}
+
+function get(): Promise<CaseItem[]> {
   const params: CasesQueryParams = {
     key: 'GSI2PK',
     value: `CREATED#${getDatePattern('YYYYMM')}`,

--- a/services/metrics-api/src/helpers/cases.ts
+++ b/services/metrics-api/src/helpers/cases.ts
@@ -1,9 +1,9 @@
 import { cases } from './query';
 import { getDatePattern } from './getDatePattern';
-import type { QueryParams, CaseItem } from './query/cases/types';
+import type { CasesQueryParams, CaseItem } from './query/cases/types';
 
 async function get(): Promise<CaseItem[]> {
-  const params: QueryParams = {
+  const params: CasesQueryParams = {
     key: 'GSI2PK',
     value: `CREATED#${getDatePattern('YYYYMM')}`,
     index: 'GSI2PK-index',

--- a/services/metrics-api/src/helpers/cases.ts
+++ b/services/metrics-api/src/helpers/cases.ts
@@ -2,6 +2,29 @@ import { cases } from './query';
 import { getDatePattern } from './getDatePattern';
 import { MetricsKey } from './metrics.constants';
 import type { CasesQueryParams, CaseItem } from './query/cases/types';
+import {
+  NEW_APPLICATION,
+  NOT_STARTED,
+  ACTIVE_ONGOING,
+  ACTIVE_ONGOING_NEW_APPLICATION,
+  ACTIVE_SIGNATURE_COMPLETED,
+  ACTIVE_SIGNATURE_PENDING,
+  ACTIVE_SUBMITTED,
+  ACTIVE_PROCESSING,
+  NEW_APPLICATION_VIVA,
+  NOT_STARTED_VIVA,
+  ACTIVE_COMPLETION_REQUIRED_VIVA,
+  ACTIVE_COMPLETION_SUBMITTED_VIVA,
+  ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
+  ACTIVE_RANDOM_CHECK_SUBMITTED_VIVA,
+  ACTIVE_NEW_APPLICATION_RANDOM_CHECK_VIVA,
+  ACTIVE_PROCESSING_COMPLETIONS_DUE_DATE_PASSED_VIVA,
+  CLOSED_APPROVED_VIVA,
+  CLOSED_PARTIALLY_APPROVED_VIVA,
+  CLOSED_REJECTED_VIVA,
+  CLOSED_COMPLETION_REJECTED_VIVA,
+  CLOSED_RANDOM_CHECK_REJECTED_VIVA,
+} from '../../../../libs/constants';
 
 export type StatusCollection = Record<MetricsKey, Record<string, number>>;
 
@@ -19,16 +42,33 @@ function casesToStatusCollectionReducer(
 
 export function createStatusCollection(cases: CaseItem[]): StatusCollection {
   const initial: StatusCollection = {
-    [MetricsKey.EKB_CASES_OPEN_TOTAL]: {},
-    [MetricsKey.EKB_CASES_CLOSED_TOTAL]: {},
+    [MetricsKey.EKB_CASES_OPEN_TOTAL]: {
+      [NEW_APPLICATION]: 0,
+      [NOT_STARTED]: 0,
+      [ACTIVE_ONGOING]: 0,
+      [ACTIVE_ONGOING_NEW_APPLICATION]: 0,
+      [ACTIVE_SIGNATURE_COMPLETED]: 0,
+      [ACTIVE_SIGNATURE_PENDING]: 0,
+      [ACTIVE_SUBMITTED]: 0,
+      [ACTIVE_PROCESSING]: 0,
+      [NEW_APPLICATION_VIVA]: 0,
+      [NOT_STARTED_VIVA]: 0,
+      [ACTIVE_COMPLETION_REQUIRED_VIVA]: 0,
+      [ACTIVE_COMPLETION_SUBMITTED_VIVA]: 0,
+      [ACTIVE_RANDOM_CHECK_REQUIRED_VIVA]: 0,
+      [ACTIVE_RANDOM_CHECK_SUBMITTED_VIVA]: 0,
+      [ACTIVE_NEW_APPLICATION_RANDOM_CHECK_VIVA]: 0,
+      [ACTIVE_PROCESSING_COMPLETIONS_DUE_DATE_PASSED_VIVA]: 0,
+    },
+    [MetricsKey.EKB_CASES_CLOSED_TOTAL]: {
+      [CLOSED_APPROVED_VIVA]: 0,
+      [CLOSED_PARTIALLY_APPROVED_VIVA]: 0,
+      [CLOSED_REJECTED_VIVA]: 0,
+      [CLOSED_COMPLETION_REJECTED_VIVA]: 0,
+      [CLOSED_RANDOM_CHECK_REJECTED_VIVA]: 0,
+    },
   };
   return cases.reduce(casesToStatusCollectionReducer, initial);
-}
-
-export function removeEmptyMetricsValues(collection: StatusCollection): StatusCollection {
-  return Object.fromEntries(
-    Object.entries(collection).filter(([, value]) => Object.values(value).some(v => v > 0))
-  ) as StatusCollection;
 }
 
 function get(): Promise<CaseItem[]> {

--- a/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
+++ b/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
@@ -1,41 +1,38 @@
-import { NOT_STARTED, ACTIVE_ONGOING, ACTIVE_SIGNATURE_PENDING } from '../../libs/constants';
-import casesRepository from '../cases';
+import casesRepository, { createStatusCollection } from '../cases';
 import MetricBuilder from '../metricBuilder';
-import { MetricType } from '../metrics.constants';
-import type { Metric, MetricValue } from '../metrics.types';
+import { MetricsHelperText, MetricType } from '../metrics.constants';
+import type { StatusCollection } from '../cases';
+import type { Metric } from '../metrics.types';
 import type { MetricsCollector } from './metricsCollector';
-import type { CaseItem } from '../query/cases/types';
 
 type CaseMeta = {
   status: string;
 };
 
-export function createCaseMetricValue(status: string, cases: CaseItem[]): MetricValue<CaseMeta> {
-  const value: number = cases.reduce(
-    (count, { status: { type } }) => (type.includes(status) ? ++count : count),
-    0
-  );
-  return { value, meta: { status } };
+function createCasesMetrics(collection: StatusCollection) {
+  const metrics = Object.entries(collection).map(([metricName, values]) => {
+    const builder = new MetricBuilder<CaseMeta>(metricName);
+
+    builder.setHelp(MetricsHelperText[metricName]);
+    builder.setType(MetricType.GAUGE);
+
+    Object.entries(values).forEach(([status, value]) => {
+      builder.addValue({ value, meta: { status } });
+    });
+
+    return builder.getMetric();
+  });
+
+  return metrics;
 }
 
-async function createCasesMetrics(cases: CaseItem[]): Promise<Metric<CaseMeta>[]> {
-  const casesMetrics: Metric<CaseMeta> = new MetricBuilder<CaseMeta>('ekb_cases_open_total')
-    .setHelp('Total number of open cases')
-    .setType(MetricType.GAUGE)
-    .addValue(createCaseMetricValue(NOT_STARTED, cases))
-    .addValue(createCaseMetricValue(ACTIVE_ONGOING, cases))
-    .addValue(createCaseMetricValue(ACTIVE_SIGNATURE_PENDING, cases))
-    .getMetric();
-
-  return [casesMetrics];
-}
-
-const ekbMetricsCollector: MetricsCollector<CaseMeta> = {
+const ekb: MetricsCollector<CaseMeta> = {
   async collect(): Promise<Metric<CaseMeta>[]> {
-    const cases: CaseItem[] = await casesRepository.get();
-    const casesMetrics: Metric<CaseMeta>[] = await createCasesMetrics(cases);
-    return [...casesMetrics];
+    const cases = await casesRepository.get();
+    const statusCollection = createStatusCollection(cases);
+    const casesMetrics = createCasesMetrics(statusCollection);
+    return casesMetrics;
   },
 };
 
-export default ekbMetricsCollector;
+export default ekb;

--- a/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
+++ b/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
@@ -5,15 +5,15 @@ import type { StatusCollection } from '../cases';
 import type { Metric } from '../metrics.types';
 import type { MetricsCollector } from './metricsCollector';
 
-type CaseMeta = {
+export type CaseMeta = {
   status: string;
 };
 
-function createCasesMetrics(collection: StatusCollection) {
+export function createCasesMetrics(collection: StatusCollection) {
   const metrics = Object.entries(collection).map(([metricName, values]) => {
     const builder = new MetricBuilder<CaseMeta>(metricName);
 
-    builder.setHelp(MetricsHelperText[metricName]);
+    builder.setHelp(MetricsHelperText[metricName as keyof typeof MetricsHelperText]);
     builder.setType(MetricType.GAUGE);
 
     Object.entries(values).forEach(([status, value]) => {

--- a/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
+++ b/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
@@ -1,4 +1,4 @@
-import casesRepository, { createStatusCollection } from '../cases';
+import casesRepository, { createStatusCollection, removeEmptyMetricsValues } from '../cases';
 import MetricBuilder from '../metricBuilder';
 import { MetricsHelperText, MetricType } from '../metrics.constants';
 import type { StatusCollection } from '../cases';
@@ -9,8 +9,10 @@ export type CaseMeta = {
   status: string;
 };
 
-export function createCasesMetrics(collection: StatusCollection) {
-  const metrics = Object.entries(collection).map(([metricName, values]) => {
+export function createCasesMetrics(collection: StatusCollection): Metric<CaseMeta>[] {
+  const collectionWithValues = removeEmptyMetricsValues(collection);
+
+  const metrics = Object.entries(collectionWithValues).map(([metricName, values]) => {
     const builder = new MetricBuilder<CaseMeta>(metricName);
 
     builder.setHelp(MetricsHelperText[metricName as keyof typeof MetricsHelperText]);

--- a/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
+++ b/services/metrics-api/src/helpers/collectors/ekbMetricsCollector.ts
@@ -1,4 +1,4 @@
-import casesRepository, { createStatusCollection, removeEmptyMetricsValues } from '../cases';
+import casesRepository, { createStatusCollection } from '../cases';
 import MetricBuilder from '../metricBuilder';
 import { MetricsHelperText, MetricType } from '../metrics.constants';
 import type { StatusCollection } from '../cases';
@@ -10,9 +10,7 @@ export type CaseMeta = {
 };
 
 export function createCasesMetrics(collection: StatusCollection): Metric<CaseMeta>[] {
-  const collectionWithValues = removeEmptyMetricsValues(collection);
-
-  const metrics = Object.entries(collectionWithValues).map(([metricName, values]) => {
+  const metrics = Object.entries(collection).map(([metricName, values]) => {
     const builder = new MetricBuilder<CaseMeta>(metricName);
 
     builder.setHelp(MetricsHelperText[metricName as keyof typeof MetricsHelperText]);

--- a/services/metrics-api/src/helpers/metricBuilder.ts
+++ b/services/metrics-api/src/helpers/metricBuilder.ts
@@ -4,48 +4,48 @@ import type { MetricType } from './metrics.constants';
 import type { MaybeMetricMeta, Metric, MetricValue } from './metrics.types';
 
 export default class MetricBuilder<TMeta extends MaybeMetricMeta = void> {
-  #metric: Metric<TMeta>;
+  private metric: Metric<TMeta>;
 
   constructor(name: string) {
-    this.#metric = {
+    this.metric = {
       name,
       values: [],
     };
   }
 
   setHelp(help: string): MetricBuilder<TMeta> {
-    this.#metric.help = help;
+    this.metric.help = help;
     return this;
   }
 
   setType(type: MetricType): MetricBuilder<TMeta> {
-    this.#metric.type = type;
+    this.metric.type = type;
     return this;
   }
 
   addValue(value: MetricValue<TMeta>): MetricBuilder<TMeta> {
     const isMetricMetaless = !isMetricValueWithMeta(value);
-    const hasValuesAlready = this.#metric.values.length > 0;
-    const hasMetalessValues = this.#metric.values.some(value => !isMetricValueWithMeta(value));
+    const hasValuesAlready = this.metric.values.length > 0;
+    const hasMetalessValues = this.metric.values.some(value => !isMetricValueWithMeta(value));
 
     const reachedMetalessLimit = (isMetricMetaless && hasValuesAlready) || hasMetalessValues;
 
     if (reachedMetalessLimit) {
       throw new Error(
-        `Metaless metric cannot contain more than 1 value (metric ${this.#metric.name})`
+        `Metaless metric cannot contain more than 1 value (metric ${this.metric.name})`
       );
     }
 
-    this.#metric.values.push(value);
+    this.metric.values.push(value);
 
     return this;
   }
 
   getMetric(): Metric<TMeta> {
-    if (this.#metric.values.length == 0) {
-      throw new Error(`No values specified for metric ${this.#metric.name}`);
+    if (this.metric.values.length == 0) {
+      throw new Error(`No values specified for metric ${this.metric.name}`);
     }
 
-    return this.#metric;
+    return this.metric;
   }
 }

--- a/services/metrics-api/src/helpers/metrics.constants.ts
+++ b/services/metrics-api/src/helpers/metrics.constants.ts
@@ -5,3 +5,16 @@ export enum MetricType {
   SUMMARY = 'summary',
   UNTYPED = 'untyped',
 }
+
+export const MetricsKey = {
+  EKB_CASES_OPEN_TOTAL: 'ekb_cases_open_total',
+  EKB_CASES_CLOSED_TOTAL: 'ekb_cases_closed_total',
+} as const;
+
+export const MetricsHelperText = {
+  [MetricsKey.EKB_CASES_OPEN_TOTAL]: 'Total number of open cases',
+  [MetricsKey.EKB_CASES_CLOSED_TOTAL]: 'Total number of closed cases',
+} as const;
+
+export type MetricsKey = typeof MetricsKey[keyof typeof MetricsKey];
+export type MetricsHelperText = typeof MetricsHelperText[keyof typeof MetricsHelperText];

--- a/services/metrics-api/src/helpers/query/cases/caseQueries.ts
+++ b/services/metrics-api/src/helpers/query/cases/caseQueries.ts
@@ -1,8 +1,8 @@
-import { caseQuaryHandler } from '../handlers/dynamoDb/caseQueryHandler';
-import type { CaseQueryHandler, QueryParams, CaseItem } from './types';
+import { casesQuaryHandler } from '../handlers/dynamoDb/caseQueryHandler';
+import type { CasesQueryHandler, CasesQueryParams, CaseItem } from './types';
 
-export const caseQueries: CaseQueryHandler = {
-  async query(params: QueryParams): Promise<CaseItem[]> {
-    return caseQuaryHandler.query(params);
+export const caseQueries: CasesQueryHandler = {
+  async query(params: CasesQueryParams): Promise<CaseItem[]> {
+    return casesQuaryHandler.query(params);
   },
 };

--- a/services/metrics-api/src/helpers/query/cases/types.ts
+++ b/services/metrics-api/src/helpers/query/cases/types.ts
@@ -7,12 +7,12 @@ export interface CaseItem {
   readonly status: CaseItemStatus;
 }
 
-export interface QueryParams {
+export interface CaseQueryParams {
   key: string;
   value: string;
   index?: string;
 }
 
 export interface CaseQueryHandler {
-  query(params: QueryParams): Promise<CaseItem[]>;
+  query(params: CaseQueryParams): Promise<CaseItem[]>;
 }

--- a/services/metrics-api/src/helpers/query/cases/types.ts
+++ b/services/metrics-api/src/helpers/query/cases/types.ts
@@ -3,16 +3,15 @@ interface CaseItemStatus {
 }
 
 export interface CaseItem {
-  readonly GSI2PK: string;
   readonly status: CaseItemStatus;
 }
 
-export interface CaseQueryParams {
+export interface CasesQueryParams {
   key: string;
   value: string;
   index?: string;
 }
 
-export interface CaseQueryHandler {
-  query(params: CaseQueryParams): Promise<CaseItem[]>;
+export interface CasesQueryHandler {
+  query(params: CasesQueryParams): Promise<CaseItem[]>;
 }

--- a/services/metrics-api/src/helpers/query/handlers/dynamoDb/caseQueryHandler.ts
+++ b/services/metrics-api/src/helpers/query/handlers/dynamoDb/caseQueryHandler.ts
@@ -1,10 +1,11 @@
 import { dynamoQueryHandler } from './queryHandler';
 import config from '../../../../libs/config';
-import type { CaseQueryHandler, QueryParams, CaseItem } from '../../cases/types';
+import type { CaseQueryHandler, CaseQueryParams, CaseItem } from '../../cases/types';
 
 export const caseQuaryHandler: CaseQueryHandler = {
-  async query(params: QueryParams) {
+  async query(params: CaseQueryParams) {
+    const { key: pk, value, index } = params;
     const casesTableName = `${config.resourcesStage}-${config.cases.tableName}`;
-    return dynamoQueryHandler.query<CaseItem[]>(casesTableName, params);
+    return dynamoQueryHandler.query<CaseItem[]>(casesTableName, { pk, value, index });
   },
 };

--- a/services/metrics-api/src/helpers/query/handlers/dynamoDb/caseQueryHandler.ts
+++ b/services/metrics-api/src/helpers/query/handlers/dynamoDb/caseQueryHandler.ts
@@ -1,9 +1,9 @@
 import { dynamoQueryHandler } from './queryHandler';
 import config from '../../../../libs/config';
-import type { CaseQueryHandler, CaseQueryParams, CaseItem } from '../../cases/types';
+import type { CasesQueryHandler, CasesQueryParams, CaseItem } from '../../cases/types';
 
-export const caseQuaryHandler: CaseQueryHandler = {
-  async query(params: CaseQueryParams) {
+export const casesQuaryHandler: CasesQueryHandler = {
+  async query(params: CasesQueryParams) {
     const { key: pk, value, index } = params;
     const casesTableName = `${config.resourcesStage}-${config.cases.tableName}`;
     return dynamoQueryHandler.query<CaseItem[]>(casesTableName, { pk, value, index });

--- a/services/metrics-api/src/helpers/query/handlers/dynamoDb/queryHandler.ts
+++ b/services/metrics-api/src/helpers/query/handlers/dynamoDb/queryHandler.ts
@@ -1,5 +1,4 @@
 import DynamoDb from 'aws-sdk/clients/dynamodb';
-import type { QueryInput } from 'aws-sdk/clients/dynamodb';
 import type { DynamoQueryHandler, QueryParams } from './types';
 
 const dynamoDbClient = new DynamoDb.DocumentClient({ apiVersion: '2012-08-10' });
@@ -7,11 +6,11 @@ const dynamoDbClient = new DynamoDb.DocumentClient({ apiVersion: '2012-08-10' })
 export const dynamoQueryHandler: DynamoQueryHandler = {
   async query<T>(tableName: string, params: QueryParams): Promise<T> {
     const { pk, value, index } = params;
-    const queryParams: QueryInput = {
+    const queryParams = {
       TableName: tableName,
       KeyConditionExpression: '#pk = :value',
       ExpressionAttributeNames: { '#pk': pk },
-      ExpressionAttributeValues: { ':value': { S: value } },
+      ExpressionAttributeValues: { ':value': value },
       ...(index && { IndexName: index }),
     };
     const result = await dynamoDbClient.query(queryParams).promise();

--- a/services/metrics-api/src/helpers/query/handlers/dynamoDb/queryHandler.ts
+++ b/services/metrics-api/src/helpers/query/handlers/dynamoDb/queryHandler.ts
@@ -1,16 +1,18 @@
 import DynamoDb from 'aws-sdk/clients/dynamodb';
+import type { QueryInput } from 'aws-sdk/clients/dynamodb';
 import type { DynamoQueryHandler, QueryParams } from './types';
 
 const dynamoDbClient = new DynamoDb.DocumentClient({ apiVersion: '2012-08-10' });
 
 export const dynamoQueryHandler: DynamoQueryHandler = {
   async query<T>(tableName: string, params: QueryParams): Promise<T> {
-    const queryParams = {
+    const { pk, value, index } = params;
+    const queryParams: QueryInput = {
       TableName: tableName,
       KeyConditionExpression: '#pk = :value',
-      ExpressionAttributeNames: { '#pk': params.key },
-      ExpressionAttributeValues: { ':value': params.value },
-      ...(params.index && { IndexName: params.index }),
+      ExpressionAttributeNames: { '#pk': pk },
+      ExpressionAttributeValues: { ':value': { S: value } },
+      ...(index && { IndexName: index }),
     };
     const result = await dynamoDbClient.query(queryParams).promise();
     return result.Items as unknown as T;

--- a/services/metrics-api/src/helpers/query/handlers/dynamoDb/types.ts
+++ b/services/metrics-api/src/helpers/query/handlers/dynamoDb/types.ts
@@ -1,5 +1,5 @@
 export interface QueryParams {
-  key: string;
+  pk: string;
   value: string;
   index?: string;
 }

--- a/services/metrics-api/src/lambdas/get.ts
+++ b/services/metrics-api/src/lambdas/get.ts
@@ -1,7 +1,7 @@
+import { wrappers } from '../libs/lambdaWrapper';
 import { ekbMetricsCollector } from '../helpers/collectors';
 import { collectFromAll } from '../helpers/collectors';
 import { getMetricFormatter } from '../helpers/formats';
-import { wrappers } from '../libs/lambdaWrapper';
 
 import type { ValidFormat } from '../helpers/formats';
 

--- a/services/metrics-api/test/helpers/cases.test.ts
+++ b/services/metrics-api/test/helpers/cases.test.ts
@@ -1,4 +1,4 @@
-import { createStatusCollection, removeEmptyMetricsValues } from '../../src/helpers/cases';
+import { createStatusCollection } from '../../src/helpers/cases';
 import type { CaseItem } from '../../src/helpers/query/cases/types';
 import type { StatusCollection } from '../../src/helpers/cases';
 
@@ -30,24 +30,34 @@ describe('createStatusCollection', () => {
 
     const expectedResult: StatusCollection = {
       ekb_cases_open_total: {
-        'notStarted:viva': 1,
-        'newApplication:viva': 3,
-        'active:ongoing': 1,
-        'active:signature:pending': 1,
-        'active:signature:completed': 1,
         'active:completionRequired': 4,
-        'active:submitted:completion:viva': 1,
+        'active:completionRequired:viva': 0,
+        'active:newApplication:randomCheckRequired:viva': 0,
+        'active:ongoing': 1,
         'active:ongoing:completion': 1,
-        'active:submitted:randomCheck': 1,
-        'active:randomCheckRequired': 1,
-        'active:processing': 1,
-        'active:submitted': 1,
         'active:ongoing:newApplication': 1,
+        'active:processing': 1,
+        'active:processing:completionsDueDatePassed:viva': 0,
+        'active:randomCheckRequired': 1,
+        'active:randomCheckRequired:viva': 0,
+        'active:signature:completed': 1,
+        'active:signature:pending': 1,
+        'active:submitted': 1,
+        'active:submitted:completion:viva': 1,
+        'active:submitted:randomCheck': 1,
+        'active:submitted:randomCheck:viva': 0,
+        newApplication: 0,
+        'newApplication:viva': 3,
+        notStarted: 0,
+        'notStarted:viva': 1,
       },
       ekb_cases_closed_total: {
         'closed:approved:viva': 1,
-        'closed:rejected:viva': 1,
+        'closed:completionRejected:viva': 0,
         'closed:partiallyApproved': 1,
+        'closed:partiallyApproved:viva': 0,
+        'closed:randomCheckRejected:viva': 0,
+        'closed:rejected:viva': 1,
       },
     };
 
@@ -60,34 +70,33 @@ describe('createStatusCollection', () => {
 
     const expectedResult: StatusCollection = {
       ekb_cases_open_total: {
+        'active:completionRequired:viva': 0,
+        'active:newApplication:randomCheckRequired:viva': 0,
+        'active:ongoing': 0,
+        'active:ongoing:newApplication': 0,
+        'active:processing': 0,
+        'active:processing:completionsDueDatePassed:viva': 0,
+        'active:randomCheckRequired:viva': 0,
+        'active:signature:completed': 0,
+        'active:signature:pending': 0,
+        'active:submitted': 0,
+        'active:submitted:completion:viva': 0,
+        'active:submitted:randomCheck:viva': 0,
+        newApplication: 0,
+        'newApplication:viva': 0,
+        notStarted: 0,
         'notStarted:viva': 1,
       },
-      ekb_cases_closed_total: {},
+      ekb_cases_closed_total: {
+        'closed:approved:viva': 0,
+        'closed:completionRejected:viva': 0,
+        'closed:partiallyApproved:viva': 0,
+        'closed:randomCheckRejected:viva': 0,
+        'closed:rejected:viva': 0,
+      },
     };
 
     const result = createStatusCollection(cases);
     expect(result).toEqual(expectedResult);
   });
 });
-
-describe('removeEmptyMetricsValues', () => {
-  it(`should remove empty status collection object`, async () => {
-    const statusCollection: StatusCollection = {
-      ekb_cases_open_total: {
-        'notStarted:viva': 10,
-      },
-      ekb_cases_closed_total: {},
-    };
-
-    const expectedResult = {
-      ekb_cases_open_total: {
-        'notStarted:viva': 10,
-      },
-    };
-
-    const result = removeEmptyMetricsValues(statusCollection);
-    expect(result).toEqual(expectedResult);
-  });
-});
-
-removeEmptyMetricsValues;

--- a/services/metrics-api/test/helpers/cases.test.ts
+++ b/services/metrics-api/test/helpers/cases.test.ts
@@ -1,0 +1,56 @@
+import { createStatusCollection } from '../../src/helpers/cases';
+import type { CaseItem } from '../../src/helpers/query/cases/types';
+import type { StatusCollection } from '../../src/helpers/cases';
+
+const cases: CaseItem[] = [
+  { status: { type: 'notStarted:viva' } },
+  { status: { type: 'closed:approved:viva' } },
+  { status: { type: 'closed:rejected:viva' } },
+  { status: { type: 'closed:partiallyApproved' } },
+  { status: { type: 'newApplication:viva' } },
+  { status: { type: 'newApplication:viva' } },
+  { status: { type: 'newApplication:viva' } },
+  { status: { type: 'active:ongoing' } },
+  { status: { type: 'active:signature:pending' } },
+  { status: { type: 'active:signature:completed' } },
+  { status: { type: 'active:completionRequired' } },
+  { status: { type: 'active:completionRequired' } },
+  { status: { type: 'active:completionRequired' } },
+  { status: { type: 'active:completionRequired' } },
+  { status: { type: 'active:submitted:completion:viva' } },
+  { status: { type: 'active:ongoing:completion' } },
+  { status: { type: 'active:submitted:randomCheck' } },
+  { status: { type: 'active:randomCheckRequired' } },
+  { status: { type: 'active:processing' } },
+  { status: { type: 'active:submitted' } },
+  { status: { type: 'active:ongoing:newApplication' } },
+];
+
+describe('createStatusCollection', () => {
+  it(`should return status collection`, async () => {
+    const expectedResult: StatusCollection = {
+      ekb_cases_open_total: {
+        'notStarted:viva': 1,
+        'newApplication:viva': 3,
+        'active:ongoing': 1,
+        'active:signature:pending': 1,
+        'active:signature:completed': 1,
+        'active:completionRequired': 4,
+        'active:submitted:completion:viva': 1,
+        'active:ongoing:completion': 1,
+        'active:submitted:randomCheck': 1,
+        'active:randomCheckRequired': 1,
+        'active:processing': 1,
+        'active:submitted': 1,
+        'active:ongoing:newApplication': 1,
+      },
+      ekb_cases_closed_total: {
+        'closed:approved:viva': 1,
+        'closed:rejected:viva': 1,
+        'closed:partiallyApproved': 1,
+      },
+    };
+    const result = createStatusCollection(cases);
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/services/metrics-api/test/helpers/cases.test.ts
+++ b/services/metrics-api/test/helpers/cases.test.ts
@@ -2,32 +2,32 @@ import { createStatusCollection } from '../../src/helpers/cases';
 import type { CaseItem } from '../../src/helpers/query/cases/types';
 import type { StatusCollection } from '../../src/helpers/cases';
 
-const cases: CaseItem[] = [
-  { status: { type: 'notStarted:viva' } },
-  { status: { type: 'closed:approved:viva' } },
-  { status: { type: 'closed:rejected:viva' } },
-  { status: { type: 'closed:partiallyApproved' } },
-  { status: { type: 'newApplication:viva' } },
-  { status: { type: 'newApplication:viva' } },
-  { status: { type: 'newApplication:viva' } },
-  { status: { type: 'active:ongoing' } },
-  { status: { type: 'active:signature:pending' } },
-  { status: { type: 'active:signature:completed' } },
-  { status: { type: 'active:completionRequired' } },
-  { status: { type: 'active:completionRequired' } },
-  { status: { type: 'active:completionRequired' } },
-  { status: { type: 'active:completionRequired' } },
-  { status: { type: 'active:submitted:completion:viva' } },
-  { status: { type: 'active:ongoing:completion' } },
-  { status: { type: 'active:submitted:randomCheck' } },
-  { status: { type: 'active:randomCheckRequired' } },
-  { status: { type: 'active:processing' } },
-  { status: { type: 'active:submitted' } },
-  { status: { type: 'active:ongoing:newApplication' } },
-];
-
 describe('createStatusCollection', () => {
   it(`should return status collection`, async () => {
+    const cases: CaseItem[] = [
+      { status: { type: 'notStarted:viva' } },
+      { status: { type: 'closed:approved:viva' } },
+      { status: { type: 'closed:rejected:viva' } },
+      { status: { type: 'closed:partiallyApproved' } },
+      { status: { type: 'newApplication:viva' } },
+      { status: { type: 'newApplication:viva' } },
+      { status: { type: 'newApplication:viva' } },
+      { status: { type: 'active:ongoing' } },
+      { status: { type: 'active:signature:pending' } },
+      { status: { type: 'active:signature:completed' } },
+      { status: { type: 'active:completionRequired' } },
+      { status: { type: 'active:completionRequired' } },
+      { status: { type: 'active:completionRequired' } },
+      { status: { type: 'active:completionRequired' } },
+      { status: { type: 'active:submitted:completion:viva' } },
+      { status: { type: 'active:ongoing:completion' } },
+      { status: { type: 'active:submitted:randomCheck' } },
+      { status: { type: 'active:randomCheckRequired' } },
+      { status: { type: 'active:processing' } },
+      { status: { type: 'active:submitted' } },
+      { status: { type: 'active:ongoing:newApplication' } },
+    ];
+
     const expectedResult: StatusCollection = {
       ekb_cases_open_total: {
         'notStarted:viva': 1,
@@ -50,6 +50,20 @@ describe('createStatusCollection', () => {
         'closed:partiallyApproved': 1,
       },
     };
+    const result = createStatusCollection(cases);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it(`should return status collection with only open cases`, async () => {
+    const cases: CaseItem[] = [{ status: { type: 'notStarted:viva' } }];
+
+    const expectedResult: StatusCollection = {
+      ekb_cases_open_total: {
+        'notStarted:viva': 1,
+      },
+      ekb_cases_closed_total: {},
+    };
+
     const result = createStatusCollection(cases);
     expect(result).toEqual(expectedResult);
   });

--- a/services/metrics-api/test/helpers/cases.test.ts
+++ b/services/metrics-api/test/helpers/cases.test.ts
@@ -1,4 +1,4 @@
-import { createStatusCollection } from '../../src/helpers/cases';
+import { createStatusCollection, removeEmptyMetricsValues } from '../../src/helpers/cases';
 import type { CaseItem } from '../../src/helpers/query/cases/types';
 import type { StatusCollection } from '../../src/helpers/cases';
 
@@ -50,6 +50,7 @@ describe('createStatusCollection', () => {
         'closed:partiallyApproved': 1,
       },
     };
+
     const result = createStatusCollection(cases);
     expect(result).toEqual(expectedResult);
   });
@@ -68,3 +69,25 @@ describe('createStatusCollection', () => {
     expect(result).toEqual(expectedResult);
   });
 });
+
+describe('removeEmptyMetricsValues', () => {
+  it(`should remove empty status collection object`, async () => {
+    const statusCollection: StatusCollection = {
+      ekb_cases_open_total: {
+        'notStarted:viva': 10,
+      },
+      ekb_cases_closed_total: {},
+    };
+
+    const expectedResult = {
+      ekb_cases_open_total: {
+        'notStarted:viva': 10,
+      },
+    };
+
+    const result = removeEmptyMetricsValues(statusCollection);
+    expect(result).toEqual(expectedResult);
+  });
+});
+
+removeEmptyMetricsValues;

--- a/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
+++ b/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
@@ -55,7 +55,7 @@ describe('createCasesMetrics', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  it(`should return only open cases metrics collection`, async () => {
+  it(`should only return metrics containing actual values`, async () => {
     const statusCollection: StatusCollection = {
       ekb_cases_open_total: {
         'notStarted:viva': 1,

--- a/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
+++ b/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
@@ -1,32 +1,57 @@
-import { ACTIVE_ONGOING } from '../../../src/libs/constants';
-import { createCaseMetricValue } from '../../../src/helpers/collectors/ekbMetricsCollector';
-import type { CaseItem } from '../../../src/helpers/query/cases/types';
+import { createCasesMetrics } from '../../../src/helpers/collectors/ekbMetricsCollector';
+import { MetricType } from '../../../src/helpers/metrics.constants';
+import type { StatusCollection } from '../../../src/helpers/cases';
+import type { CaseMeta } from '../../../src/helpers/collectors/ekbMetricsCollector';
+import type { Metric } from '../../../src/helpers/metrics.types';
 
-const cases: CaseItem[] = [
-  {
-    GSI2PK: 'CREATED#202201',
-    status: {
-      type: 'active:ongoing',
-    },
+const statusCollection: StatusCollection = {
+  ekb_cases_open_total: {
+    'notStarted:viva': 1,
+    'newApplication:viva': 10,
   },
-  {
-    GSI2PK: 'CREATED#202201',
-    status: {
-      type: 'active:ongoing:randomCheck',
-    },
+  ekb_cases_closed_total: {
+    'closed:approved:viva': 2,
   },
-];
+};
 
-describe('createCaseMetricValue', () => {
-  it(`should return 2 ekb case metric value if status contains: ${ACTIVE_ONGOING}`, async () => {
-    const expected = {
-      value: 2,
-      meta: {
-        status: ACTIVE_ONGOING,
+describe('createCasesMetrics', () => {
+  it(`should return cases metrics collection`, async () => {
+    const expectedResult: Metric<CaseMeta>[] = [
+      {
+        name: 'ekb_cases_open_total',
+        help: 'Total number of open cases',
+        type: MetricType.GAUGE,
+        values: [
+          {
+            value: 1,
+            meta: {
+              status: 'notStarted:viva',
+            },
+          },
+          {
+            value: 10,
+            meta: {
+              status: 'newApplication:viva',
+            },
+          },
+        ],
       },
-    };
+      {
+        name: 'ekb_cases_closed_total',
+        help: 'Total number of closed cases',
+        type: MetricType.GAUGE,
+        values: [
+          {
+            value: 2,
+            meta: {
+              status: 'closed:approved:viva',
+            },
+          },
+        ],
+      },
+    ];
 
-    const result = createCaseMetricValue(ACTIVE_ONGOING, cases);
-    expect(result).toEqual(expected);
+    const result = createCasesMetrics(statusCollection);
+    expect(result).toEqual(expectedResult);
   });
 });

--- a/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
+++ b/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
@@ -55,12 +55,38 @@ describe('createCasesMetrics', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  it(`should only return metrics containing actual values`, async () => {
+  it(`should return metrics for every status`, async () => {
     const statusCollection: StatusCollection = {
       ekb_cases_open_total: {
-        'notStarted:viva': 1,
+        'active:completionRequired': 0,
+        'active:completionRequired:viva': 0,
+        'active:newApplication:randomCheckRequired:viva': 0,
+        'active:ongoing': 0,
+        'active:ongoing:completion': 0,
+        'active:ongoing:newApplication': 0,
+        'active:processing': 0,
+        'active:processing:completionsDueDatePassed:viva': 0,
+        'active:randomCheckRequired': 0,
+        'active:randomCheckRequired:viva': 0,
+        'active:signature:completed': 0,
+        'active:signature:pending': 0,
+        'active:submitted': 0,
+        'active:submitted:completion:viva': 0,
+        'active:submitted:randomCheck': 0,
+        'active:submitted:randomCheck:viva': 0,
+        newApplication: 0,
+        'newApplication:viva': 0,
+        notStarted: 0,
+        'notStarted:viva': 0,
       },
-      ekb_cases_closed_total: {},
+      ekb_cases_closed_total: {
+        'closed:approved:viva': 0,
+        'closed:completionRejected:viva': 0,
+        'closed:partiallyApproved': 0,
+        'closed:partiallyApproved:viva': 0,
+        'closed:randomCheckRejected:viva': 0,
+        'closed:rejected:viva': 0,
+      },
     };
 
     const expectedResult: Metric<CaseMeta>[] = [
@@ -69,12 +95,39 @@ describe('createCasesMetrics', () => {
         help: 'Total number of open cases',
         type: MetricType.GAUGE,
         values: [
-          {
-            value: 1,
-            meta: {
-              status: 'notStarted:viva',
-            },
-          },
+          { value: 0, meta: { status: 'active:completionRequired' } },
+          { value: 0, meta: { status: 'active:completionRequired:viva' } },
+          { value: 0, meta: { status: 'active:newApplication:randomCheckRequired:viva' } },
+          { value: 0, meta: { status: 'active:ongoing' } },
+          { value: 0, meta: { status: 'active:ongoing:completion' } },
+          { value: 0, meta: { status: 'active:ongoing:newApplication' } },
+          { value: 0, meta: { status: 'active:processing' } },
+          { value: 0, meta: { status: 'active:processing:completionsDueDatePassed:viva' } },
+          { value: 0, meta: { status: 'active:randomCheckRequired' } },
+          { value: 0, meta: { status: 'active:randomCheckRequired:viva' } },
+          { value: 0, meta: { status: 'active:signature:completed' } },
+          { value: 0, meta: { status: 'active:signature:pending' } },
+          { value: 0, meta: { status: 'active:submitted' } },
+          { value: 0, meta: { status: 'active:submitted:completion:viva' } },
+          { value: 0, meta: { status: 'active:submitted:randomCheck' } },
+          { value: 0, meta: { status: 'active:submitted:randomCheck:viva' } },
+          { value: 0, meta: { status: 'newApplication' } },
+          { value: 0, meta: { status: 'newApplication:viva' } },
+          { value: 0, meta: { status: 'notStarted' } },
+          { value: 0, meta: { status: 'notStarted:viva' } },
+        ],
+      },
+      {
+        name: 'ekb_cases_closed_total',
+        help: 'Total number of closed cases',
+        type: MetricType.GAUGE,
+        values: [
+          { value: 0, meta: { status: 'closed:approved:viva' } },
+          { value: 0, meta: { status: 'closed:completionRejected:viva' } },
+          { value: 0, meta: { status: 'closed:partiallyApproved' } },
+          { value: 0, meta: { status: 'closed:partiallyApproved:viva' } },
+          { value: 0, meta: { status: 'closed:randomCheckRejected:viva' } },
+          { value: 0, meta: { status: 'closed:rejected:viva' } },
         ],
       },
     ];

--- a/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
+++ b/services/metrics-api/test/helpers/collectors/ekbMetricsCollector.test.ts
@@ -4,18 +4,18 @@ import type { StatusCollection } from '../../../src/helpers/cases';
 import type { CaseMeta } from '../../../src/helpers/collectors/ekbMetricsCollector';
 import type { Metric } from '../../../src/helpers/metrics.types';
 
-const statusCollection: StatusCollection = {
-  ekb_cases_open_total: {
-    'notStarted:viva': 1,
-    'newApplication:viva': 10,
-  },
-  ekb_cases_closed_total: {
-    'closed:approved:viva': 2,
-  },
-};
-
 describe('createCasesMetrics', () => {
   it(`should return cases metrics collection`, async () => {
+    const statusCollection: StatusCollection = {
+      ekb_cases_open_total: {
+        'notStarted:viva': 1,
+        'newApplication:viva': 10,
+      },
+      ekb_cases_closed_total: {
+        'closed:approved:viva': 2,
+      },
+    };
+
     const expectedResult: Metric<CaseMeta>[] = [
       {
         name: 'ekb_cases_open_total',
@@ -45,6 +45,34 @@ describe('createCasesMetrics', () => {
             value: 2,
             meta: {
               status: 'closed:approved:viva',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = createCasesMetrics(statusCollection);
+    expect(result).toEqual(expectedResult);
+  });
+
+  it(`should return only open cases metrics collection`, async () => {
+    const statusCollection: StatusCollection = {
+      ekb_cases_open_total: {
+        'notStarted:viva': 1,
+      },
+      ekb_cases_closed_total: {},
+    };
+
+    const expectedResult: Metric<CaseMeta>[] = [
+      {
+        name: 'ekb_cases_open_total',
+        help: 'Total number of open cases',
+        type: MetricType.GAUGE,
+        values: [
+          {
+            value: 1,
+            meta: {
+              status: 'notStarted:viva',
             },
           },
         ],

--- a/services/metrics-api/test/lambdas/get.test.ts
+++ b/services/metrics-api/test/lambdas/get.test.ts
@@ -40,7 +40,7 @@ function createDependencies(): Dependencies {
   };
 }
 
-it('should return ekb cases metrics', async () => {
+it('should return ekb cases metrics string in EBNF format', async () => {
   const expected = [
     '# HELP ekb_cases_open_total Total number of open cases',
     '# TYPE ekb_cases_open_total gauge',


### PR DESCRIPTION
Dynamicly creates metrics based on status types.

## How to test

Concrete example:

1. Checkout this branch
2. run `sls deploy` within service folder for `service metrics-api` and `viva-ms`
3. add cases to cases table with attributs GSI2PK set to 'CREATED#202301'
4. set attribute status.type to 'notStarted' or eq (look at possible values in libs/constants.js)
5. hit endpoint /metrics/ekb?format=ebnf
6. verify output
