### PR TITLE
Feat/save viva case

### DIFF
--- a/services/viva/api/cases/test/lambdas/addCasePerson.test.ts
+++ b/services/viva/api/cases/test/lambdas/addCasePerson.test.ts
@@ -48,6 +48,7 @@ const caseItem: CaseItem = {
   createdAt: 0,
   currentFormId: '123abc',
   details: {
+    vivaCaseId: '123',
     period: {
       startDate: 0,
       endDate: 0,

--- a/services/viva/microservice/src/lambdas/createNewVivaCase.ts
+++ b/services/viva/microservice/src/lambdas/createNewVivaCase.ts
@@ -181,6 +181,7 @@ export async function createNewVivaCase(
     provider: CASE_PROVIDER_VIVA,
     persons: initialPersonList,
     details: {
+      vivaCaseId: null,
       workflowId: null,
       period: {
         startDate: createCaseHelper.createPeriodStartDate(),

--- a/services/viva/microservice/src/lambdas/createVivaCase.ts
+++ b/services/viva/microservice/src/lambdas/createVivaCase.ts
@@ -75,6 +75,11 @@ export interface Dependencies {
   createInitialForms: () => Promise<Record<string, CaseForm>>;
 }
 
+function createVivaCaseId({ idenclair }: VivaMyPagesVivaCase): string {
+  const [, vivaCaseId] = idenclair.split('/');
+  return vivaCaseId;
+}
+
 function generateInitialRecurringCase(params: InitialRecurringCaseParams): CaseItem {
   const { workflowId, currentFormId, vivaMyPages, vivaPeriod } = params;
 
@@ -91,6 +96,7 @@ function generateInitialRecurringCase(params: InitialRecurringCaseParams): CaseI
   const status: CaseStatus = getStatusByType(NOT_STARTED_VIVA);
   const persons: CasePerson[] = createCaseHelper.getCasePersonList(vivaMyPages);
   const expirationTime = millisecondsToSeconds(getFutureTimestamp(TWELVE_HOURS));
+  const vivaCaseId = createVivaCaseId(vivaMyPages);
 
   const initialRecurringCase: CaseItem = {
     id,
@@ -106,6 +112,7 @@ function generateInitialRecurringCase(params: InitialRecurringCaseParams): CaseI
     provider: CASE_PROVIDER_VIVA,
     persons,
     details: {
+      vivaCaseId,
       workflowId,
       period,
       completions: null,

--- a/services/viva/microservice/test/helpers/caseTemplate/mocks/newApplicationCaseItem.json
+++ b/services/viva/microservice/test/helpers/caseTemplate/mocks/newApplicationCaseItem.json
@@ -9,6 +9,7 @@
       "endDate": 0,
       "startDate": 1670457600000
     },
+    "vivaCaseId": "123",
     "workflowId": "4F291723569A5F8BC12589120044B0B5"
   },
   "expirationTime": 1674390610,

--- a/services/viva/microservice/test/helpers/createCase.test.ts
+++ b/services/viva/microservice/test/helpers/createCase.test.ts
@@ -60,6 +60,7 @@ const vivaOfficerSingle: VivaOfficersOfficer = {
 };
 
 const vivaCaseClientOnly: VivaMyPagesVivaCase = {
+  idenclair: '123',
   client: vivaClient,
   officers: vivaOfficerSingle,
   persons: {
@@ -68,6 +69,7 @@ const vivaCaseClientOnly: VivaMyPagesVivaCase = {
 };
 
 const vivaCaseWithPersonList: VivaMyPagesVivaCase = {
+  idenclair: '123',
   client: vivaClient,
   officers: vivaOfficerSingle,
   persons: vivaPersonList,

--- a/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createNewVivaCase.test.ts
@@ -74,6 +74,7 @@ it('successfully creates a new application case', async () => {
     PK: `USER#${user.personalNumber}`,
     currentFormId: readParametersResponse.newApplicationFormId,
     details: {
+      vivaCaseId: null,
       period: {
         startDate: 1640995200000,
         endDate: 0,

--- a/services/viva/microservice/test/lambdas/createVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createVivaCase.test.ts
@@ -144,6 +144,7 @@ function createLambdaInput(persons: VivaPersonsPerson | null = null): LambdaRequ
     detail: {
       clientUser: { ...user },
       myPages: {
+        idenclair: '01-2021-09-30/R37992',
         client: {
           pnumber: user.personalNumber,
           fname: user.firstName,
@@ -175,6 +176,7 @@ it('successfully creates a recurring application case', async () => {
           startDate: 1640995200000,
           endDate: 1643587200000,
         },
+        vivaCaseId: 'R37992',
         workflowId: null,
         completions: null,
       },
@@ -232,6 +234,7 @@ it('successfully creates a prepopulated recurring application case', async () =>
       GSI2PK: 'CREATED#202201',
       currentFormId: readParametersResponse.recurringFormId,
       details: {
+        vivaCaseId: 'R37992',
         period: {
           startDate: 1640995200000,
           endDate: 1643587200000,
@@ -307,6 +310,7 @@ it('successfully creates a recurring application case with partner', async () =>
       GSI2PK: 'CREATED#202201',
       currentFormId: readParametersResponse.recurringFormId,
       details: {
+        vivaCaseId: 'R37992',
         period: {
           startDate: 1640995200000,
           endDate: 1643587200000,

--- a/services/viva/microservice/test/lambdas/submitApplications.test.ts
+++ b/services/viva/microservice/test/lambdas/submitApplications.test.ts
@@ -22,6 +22,7 @@ const form: CaseForm = {
 };
 
 const details: CaseDetails = {
+  vivaCaseId: '123',
   workflowId: 'workflowId',
   completions: null,
   period: {

--- a/services/viva/microservice/test/lambdas/submitCompletion.test.ts
+++ b/services/viva/microservice/test/lambdas/submitCompletion.test.ts
@@ -42,6 +42,7 @@ function createCase(partialCase: Partial<CaseItem> = {}): CaseItem {
     provider: 'VIVA',
     persons: [],
     details: {
+      vivaCaseId: '123',
       period: {
         endDate: 1,
         startDate: 2,

--- a/services/viva/microservice/test/lambdas/syncCaseCompletions.test.ts
+++ b/services/viva/microservice/test/lambdas/syncCaseCompletions.test.ts
@@ -1,12 +1,9 @@
-import {
-  syncCaseCompletions,
-  Dependencies,
-  LambdaRequest,
-} from '../../src/lambdas/syncCaseCompletions';
+import type { Dependencies, LambdaRequest } from '../../src/lambdas/syncCaseCompletions';
+import { syncCaseCompletions } from '../../src/lambdas/syncCaseCompletions';
 
 import type { CaseItem } from '../../../types/caseItem';
 import { EncryptionType } from '../../../types/caseItem';
-import { VadaWorkflowCompletions } from '../../src/types/vadaCompletions';
+import type { VadaWorkflowCompletions } from '../../src/types/vadaCompletions';
 
 const caseKeys = {
   PK: 'PK',
@@ -64,6 +61,7 @@ const caseToUpdate: CaseItem = {
   },
   provider: 'VIVA',
   details: {
+    vivaCaseId: '123',
     workflowId,
     period: {
       startDate: 1,

--- a/services/viva/types/caseItem.ts
+++ b/services/viva/types/caseItem.ts
@@ -64,6 +64,7 @@ export interface CaseAdministrator {
 
 export interface CaseDetails {
   workflowId: string | null;
+  readonly vivaCaseId: string | null;
   period: CasePeriod;
   readonly workflow?: unknown;
   completions: CaseCompletions | null;

--- a/services/viva/types/vivaMyPages.ts
+++ b/services/viva/types/vivaMyPages.ts
@@ -29,6 +29,7 @@ export interface VivaMyPagesVivaCases {
 }
 
 export interface VivaMyPagesVivaCase {
+  readonly idenclair: string;
   readonly client: VivaClient;
   readonly officers?: VivaOfficersOfficer;
   readonly persons: VivaPersonsPerson | null;


### PR DESCRIPTION
## Explain the changes you’ve made
Added new attribute - vivaCaseId

## Explain why these changes are made
To be displayed on the case card in the client app so the user can reference the case when in contact with EKB officer for authentication.

## How to test
1. Checkout this branch
2. run `sls deploy` within service folder for `service viva ms`
3. Have an open recurring viva period open for the test client
4. Make an getCaseList (GET) request using PostMan or eq. and verify that vivaCaseID is set in details object
