### PR TITLE
fix(createvivacase): use previous case answer instead of applicant info if possible

### DIFF
--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -103,24 +103,26 @@ function getMultipleFieldAnswers(field, previousAnswers) {
   return answers;
 }
 
-function getInitialValue(field, applicants, previousAnswers) {
+function getApplicantInfoValue(pattern, applicants) {
   const applicantRoles = ['applicant', 'coApplicant'];
-  let initialValue;
+  const parts = pattern.split('.');
+  const role = parts[0];
+  if (applicantRoles.includes(role)) {
+    const person = applicants.find(applicant => applicant.role === role);
+    return getPersonInfo(person, parts.slice(1));
+  }
+  return undefined;
+}
 
-  field.loadPrevious.forEach(matchPattern => {
-    initialValue = getCaseAnswer(previousAnswers, matchPattern) || initialValue;
+function getInitialValue(field, applicants, previousAnswers) {
+  const firstValue = field.loadPrevious
+    .map(
+      pattern =>
+        getCaseAnswer(previousAnswers, pattern) || getApplicantInfoValue(pattern, applicants)
+    )
+    .filter(value => value !== undefined)[0];
 
-    if (!initialValue) {
-      const patternParts = matchPattern.split('.');
-      if (applicantRoles.includes(patternParts[0])) {
-        const applicantRole = patternParts[0];
-        const person = applicants.find(applicant => applicant.role === applicantRole);
-        initialValue = getPersonInfo(person, patternParts.slice(1)) || initialValue;
-      }
-    }
-  });
-
-  return initialValue ? formatAnswer(field.id, field.tags, initialValue) : undefined;
+  return firstValue ? formatAnswer(field.id, field.tags, firstValue) : undefined;
 }
 
 function populateAnswers(dataMap, applicants, previousAnswers) {

--- a/libs/formAnswers.js
+++ b/libs/formAnswers.js
@@ -108,15 +108,16 @@ function getInitialValue(field, applicants, previousAnswers) {
   let initialValue;
 
   field.loadPrevious.forEach(matchPattern => {
-    const patternParts = matchPattern.split('.');
-    if (applicantRoles.includes(patternParts[0])) {
-      const applicantRole = patternParts[0];
-      const person = applicants.find(applicant => applicant.role === applicantRole);
-      initialValue = getPersonInfo(person, patternParts.slice(1)) || initialValue;
-      return;
-    }
-
     initialValue = getCaseAnswer(previousAnswers, matchPattern) || initialValue;
+
+    if (!initialValue) {
+      const patternParts = matchPattern.split('.');
+      if (applicantRoles.includes(patternParts[0])) {
+        const applicantRole = patternParts[0];
+        const person = applicants.find(applicant => applicant.role === applicantRole);
+        initialValue = getPersonInfo(person, patternParts.slice(1)) || initialValue;
+      }
+    }
   });
 
   return initialValue ? formatAnswer(field.id, field.tags, initialValue) : undefined;

--- a/services/viva/microservice/test/lambdas/createVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createVivaCase.test.ts
@@ -26,7 +26,6 @@ import type {
 } from '../../src/types/caseItem';
 
 const MOCK_DATE = dayjs('2022-01-01T00:00:00Z');
-jest.useFakeTimers('modern').setSystemTime(MOCK_DATE.unix() * 1000);
 
 const mockUuid = '00000000-0000-0000-0000-000000000000';
 jest.mock('uuid', () => ({ v4: () => mockUuid }));

--- a/services/viva/microservice/test/lambdas/createVivaCase.test.ts
+++ b/services/viva/microservice/test/lambdas/createVivaCase.test.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import dayjs from 'dayjs';
 
 import { getStatusByType } from '../../src/libs/caseStatuses';
@@ -11,8 +12,18 @@ import { CASE_PROVIDER_VIVA, VIVA_CASE_CREATED, NOT_STARTED_VIVA } from '../../s
 
 import type { PeriodConfig } from '../../src/helpers/vivaPeriod';
 import type { VivaPersonsPerson } from '../../src/types/vivaMyPages';
-import type { LambdaRequest, DynamoDbPutParams } from '../../src/lambdas/createVivaCase';
-import type { CaseItem, CaseForm, CaseUser, CasePerson } from '../../src/types/caseItem';
+import type {
+  LambdaRequest,
+  DynamoDbPutParams,
+  Dependencies,
+} from '../../src/lambdas/createVivaCase';
+import type {
+  CaseItem,
+  CaseForm,
+  CaseUser,
+  CasePerson,
+  CaseFormAnswer,
+} from '../../src/types/caseItem';
 
 const MOCK_DATE = dayjs('2022-01-01T00:00:00Z');
 jest.useFakeTimers('modern').setSystemTime(MOCK_DATE.unix() * 1000);
@@ -130,7 +141,7 @@ const applicantFormProperties = {
     },
     {
       field: {
-        id: 'housingInfo.postalAdress',
+        id: 'housingInfo.postalAddress',
         tags: [],
       },
       value: 'KIRUNA',
@@ -172,6 +183,83 @@ function createLambdaInput(persons: VivaPersonsPerson | null = null): LambdaRequ
       },
     },
   };
+}
+
+function createMockForm(answers: CaseFormAnswer[]): CaseForm {
+  return {
+    answers,
+    currentPosition: { ...DEFAULT_CURRENT_POSITION },
+    encryption: {
+      symmetricKeyName: mockUuid,
+      encryptionKeyId: mockUuid,
+      type: EncryptionType.Decrypted,
+    },
+  };
+}
+
+function createMockCase(mockRecurringForm: CaseForm): CaseItem {
+  return {
+    id: mockUuid,
+    PK: `USER#${user.personalNumber}`,
+    SK: `CASE#${mockUuid}`,
+    GSI2PK: 'CREATED#202201',
+    currentFormId: readParametersResponse.recurringFormId,
+    details: {
+      vivaCaseId: 'R37992',
+      period: {
+        startDate: 1640995200000,
+        endDate: 1643587200000,
+      },
+      workflowId: null,
+      completions: null,
+    },
+    forms: {
+      [readParametersResponse.recurringFormId]: mockRecurringForm,
+      [readParametersResponse.randomCheckFormId]: defaultFormProperties,
+      [readParametersResponse.completionFormId]: defaultFormProperties,
+    },
+    persons: [
+      {
+        firstName: user.firstName,
+        lastName: user.lastName,
+        hasSigned: false,
+        personalNumber: user.personalNumber,
+        role: CasePersonRole.Applicant,
+      },
+    ],
+    provider: CASE_PROVIDER_VIVA,
+    state: VIVA_CASE_CREATED,
+    status: getStatusByType(NOT_STARTED_VIVA),
+    updatedAt: 0,
+    createdAt: 1640995200000,
+    expirationTime: 1641038400,
+  };
+}
+
+function createMockDependencies(value: Partial<Dependencies>): Dependencies {
+  return _.merge(
+    {
+      createCase: () => Promise.resolve(),
+      getRecurringFormId: () => Promise.resolve(readParametersResponse.recurringFormId),
+      getLastUpdatedCase: () => Promise.resolve(undefined),
+      getCaseListByPeriod: () =>
+        Promise.resolve({
+          Items: [],
+          Count: 0,
+          ScannedCount: 1,
+        }),
+      getFormTemplates: () =>
+        Promise.resolve({ [readParametersResponse.recurringFormId]: formRecurring }),
+      createInitialForms: () =>
+        Promise.resolve({
+          [readParametersResponse.recurringFormId]: defaultFormProperties,
+          [readParametersResponse.randomCheckFormId]: defaultFormProperties,
+          [readParametersResponse.completionFormId]: defaultFormProperties,
+        }),
+      getPeriodConfig: getMockPeriodConfig,
+    },
+    value
+  );
 }
 
 describe('createVivaCase', () => {
@@ -316,6 +404,70 @@ describe('createVivaCase', () => {
 
     expect(result).toBe(true);
     expect(createCaseMock).toHaveBeenCalledWith(expectedParameters);
+  });
+
+  it('prepopulates with previous case prioritized over user information', async () => {
+    const latestCaseAnswers: CaseFormAnswer[] = [
+      {
+        field: {
+          id: 'personalInfo.telephone',
+          tags: ['phonenumber', 'applicant'],
+        },
+        value: '0767123456',
+      },
+      {
+        field: {
+          id: 'personalInfo.email',
+          tags: ['email', 'applicant'],
+        },
+        value: 'case@example.com',
+      },
+    ];
+
+    const latestCaseItem = createMockCase(createMockForm(latestCaseAnswers));
+
+    const expectedAnswers: CaseFormAnswer[] = [
+      ...latestCaseAnswers,
+      {
+        field: {
+          id: 'housingInfo.streetAddress',
+          tags: [],
+        },
+        value: 'MANGIGATAN 2',
+      },
+      {
+        field: {
+          id: 'housingInfo.postalCode',
+          tags: [],
+        },
+        value: '98133',
+      },
+      {
+        field: {
+          id: 'housingInfo.postalAddress',
+          tags: [],
+        },
+        value: 'KIRUNA',
+      },
+    ];
+
+    const expectedCaseItem = createMockCase(createMockForm(expectedAnswers));
+
+    const createCaseMock = jest.fn();
+
+    const result = await createVivaCase(
+      createLambdaInput(),
+      createMockDependencies({
+        createCase: createCaseMock,
+        getLastUpdatedCase: () => Promise.resolve(latestCaseItem),
+      })
+    );
+
+    expect(result).toBe(true);
+    expect(createCaseMock).toHaveBeenCalledWith({
+      TableName: 'cases',
+      Item: expectedCaseItem,
+    });
   });
 
   it('successfully creates a recurring application case with partner', async () => {

--- a/services/viva/microservice/test/mock/formRecurring.json
+++ b/services/viva/microservice/test/mock/formRecurring.json
@@ -1871,9 +1871,9 @@
             },
             {
               "inputSelectValue": "text",
-              "key": "postalAdress",
+              "key": "postalAddress",
               "label": "Ort",
-              "loadPrevious": ["postalAdress", "applicant.address.city"],
+              "loadPrevious": ["postalAddress", "applicant.address.city"],
               "type": "text",
               "validation": {
                 "isRequired": true,


### PR DESCRIPTION
## Explain the changes you’ve made

Prioritized using answers from any previous case over using user information when pre-populating address, phone etc.

## Explain why these changes are made

The last case if any holds the most up-to-date information as the users table info is not updated.

## How to test

Concrete example:

1. Checkout this branch
2. Delete any existing cases and create a new case for an applicant
3. Verify the created case and form have answers for address etc. that matches the info in the users table
4. Fill out the case with a different address and submit
5. Create a new case for the same user
6. Verify the new case form have answers for address etc. that matches the info provided in the last case
