### PR TITLE
feat: change initial description for random check to use absolute date

### DIFF
--- a/libs/caseStatuses.js
+++ b/libs/caseStatuses.js
@@ -130,7 +130,7 @@ const statuses = [
     type: ACTIVE_RANDOM_CHECK_REQUIRED_VIVA,
     name: 'Stickprovskontroll',
     description:
-      'Du måste komplettera din ansökan med bilder som visar dina utgifter och inkomster. Vi behöver din komplettering inom 3 dagar för att kunna betala ut pengar för perioden',
+      'Du måste komplettera din ansökan med bilder som visar dina utgifter och inkomster. Vi behöver din komplettering senast #COMPLETION_DUEDATE för att kunna betala ut pengar för perioden',
   },
   {
     type: ACTIVE_RANDOM_CHECK_SUBMITTED_VIVA,


### PR DESCRIPTION
## Explain the changes you’ve made

Changed initial description for random check from this:
![image](https://user-images.githubusercontent.com/2890987/223756167-4db93402-546d-4b80-854c-5a9a3c8b2f0e.png)

To this:
![image](https://user-images.githubusercontent.com/2890987/223755924-ba0a72bd-3ce8-4e95-b75a-d50262ccaf04.png)

## Explain why these changes are made

The initial "3 dagar" text is unclear if the applicant does not see or start their random check within the first day. It is unclear when it actually ends.

## How to test

Concrete example:

1. Checkout this branch
2. Deploy stuff
3. Fill out a case and fall into random check
4. Verify date shows and is correct (by default 3 days ahead)
