### PR TITLE
fix(generaterecurringcasehtml): add array-check for checking changed …

### DIFF
--- a/services/viva/microservice/src/lambdas/generateRecurringCaseHtml.ts
+++ b/services/viva/microservice/src/lambdas/generateRecurringCaseHtml.ts
@@ -164,13 +164,19 @@ export async function generateRecurringCaseHtml(
       (caseA, caseB) => caseB.updatedAt - caseA.updatedAt
     );
 
-    changedAnswerValues = getChangedCaseAnswerValues(
-      caseItem.forms[formIds.recurringFormId].answers,
+    const latestClosedCaseForm =
       latestClosedCase.forms[
         isFormNewApplication(formIds, latestClosedCase.currentFormId)
           ? formIds.newApplicationFormId
           : formIds.recurringFormId
-      ].answers
+      ];
+    const latestClosedCaseAnswers = Array.isArray(latestClosedCaseForm?.answers)
+      ? latestClosedCaseForm.answers
+      : [];
+
+    changedAnswerValues = getChangedCaseAnswerValues(
+      caseItem.forms[formIds.recurringFormId].answers,
+      latestClosedCaseAnswers
     );
   }
 


### PR DESCRIPTION
## Explain the changes you’ve made

Check if previous answers is an array before using to check for changed answers.

## Explain why these changes are made

Generating HTML crashed when previous answers existed but were still encrypted (object instead of an array).

## How to test

Concrete example:

1. Checkout this branch
2. Have a closed case with encrypted answers for the "a1ce" form (recurring) (`answers: { encryptedAnswers: "bla" }`)
3. Fill out and submit a new case
4. Verify HTML/PDF generates correctly and the case is submitted to VIVA
